### PR TITLE
Adding .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.m4
+
+/build-mac/build
+/build-mac/include
+/config.guess
+/config.h.in
+/config.sub
+/ltmain.sh


### PR DESCRIPTION
After building libetpan and then running `make distclean` I still had some files left over, even after loading up defunkt's [gitignore/Autotools.gitignore](https://github.com/github/gitignore/blob/master/Autotools.gitignore). So I added this .gitignore until `distclean` can be made to clean up these extra files.
