### PR TITLE
Response code 201 is ok after MODE READER

### DIFF
--- a/src/low-level/nntp/newsnntp.c
+++ b/src/low-level/nntp/newsnntp.c
@@ -1312,6 +1312,7 @@ int newsnntp_mode_reader(newsnntp * f)
     return NEWSNNTP_WARNING_REQUEST_AUTHORIZATION_PASSWORD;
       
   case 200:
+  case 201:
     return NEWSNNTP_NO_ERROR;
 
   default:


### PR DESCRIPTION
cf. http://tools.ietf.org/html/rfc3977#section-5.3

Not considering 201 as Ok prevents newsreaders using libetpan to work
correctly when it happens: without the patch they get
UNEXPECTED_RESPONSE.

Ref. bug #3390872 https://sourceforge.net/tracker/?func=detail&aid=3390872&group_id=41064&atid=429696

Signed-off-by: Sébastien Bigaret sebastien.bigaret@telecom-bretagne.eu
