### PR TITLE
do not pass freed pointer to caller

### DIFF
--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -1410,6 +1410,7 @@ mailimap_uid_fetch(mailimap * session,
 
   default:
     mailimap_fetch_list_free(* result);
+    * result = NULL;
     return MAILIMAP_ERROR_UID_FETCH;
   }
 }


### PR DESCRIPTION
Is there a good reason to not set *result = NULL after freeing it?  It is confusing for the caller to get a pointer back that has already been freed.  
