### PR TITLE
check for null mailstream pointer in mailstream_close

### DIFF
--- a/src/data-types/mailstream.c
+++ b/src/data-types/mailstream.c
@@ -281,6 +281,10 @@ void mailstream_set_low(mailstream * s, mailstream_low * low)
 
 int mailstream_close(mailstream * s)
 {
+    
+  if (s == NULL)
+      return 0;
+    
   if (s->idle != NULL) {
     mailstream_cancel_free(s->idle);
   }


### PR DESCRIPTION
if you have allocated a mailimap\* and pass it to mailimap_logout without having connected first, it may not have a imap_stream and it will crash in mailstream_close.
