### PR TITLE
Add GMail X-MSG-ID Support

### DIFF
--- a/build-mac/libetpan.xcodeproj/project.pbxproj
+++ b/build-mac/libetpan.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		365DFFD215D1C93100F2DD85 /* xgmmsgid.c in Sources */ = {isa = PBXBuildFile; fileRef = 365DFFD115D1C93100F2DD85 /* xgmmsgid.c */; };
+		365DFFD915D1CF1800F2DD85 /* xgmmsgid.h in Headers */ = {isa = PBXBuildFile; fileRef = 365DFFD815D1CF1800F2DD85 /* xgmmsgid.h */; };
+		365DFFDB15D1CF6D00F2DD85 /* xgmmsgid.h in Headers */ = {isa = PBXBuildFile; fileRef = 365DFFDA15D1CF6D00F2DD85 /* xgmmsgid.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		365DFFDF15D1F2F800F2DD85 /* mailstream_cfstream.h in Headers */ = {isa = PBXBuildFile; fileRef = 365DFFDE15D1F2F800F2DD85 /* mailstream_cfstream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		365DFFE515D1F3CD00F2DD85 /* xgmlabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 365DFFE415D1F3CD00F2DD85 /* xgmlabels.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C6451AFE1083D316003135FD /* mailimf_write.h in Headers */ = {isa = PBXBuildFile; fileRef = C6F9EA32105335BC0059C3BA /* mailimf_write.h */; };
 		C6451AFF1083D316003135FD /* mhdriver_cached.h in Headers */ = {isa = PBXBuildFile; fileRef = C6F9E913105335BC0059C3BA /* mhdriver_cached.h */; };
 		C6451B001083D316003135FD /* mhdriver_types.h in Headers */ = {isa = PBXBuildFile; fileRef = C6F9E91A105335BC0059C3BA /* mhdriver_types.h */; };
@@ -364,12 +369,12 @@
 		C682E2BB15B315EF00BE9DA7 /* xgmlabels.c in Sources */ = {isa = PBXBuildFile; fileRef = C6CE9B1514AA9C8900D20BA6 /* xgmlabels.c */; };
 		C68C6206130FFE7E00F16728 /* namespace_parser.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C61FE130FFE7E00F16728 /* namespace_parser.h */; };
 		C68C6207130FFE7E00F16728 /* namespace_sender.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C61FF130FFE7E00F16728 /* namespace_sender.h */; };
-		C68C6208130FFE7E00F16728 /* namespace_types.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6200130FFE7E00F16728 /* namespace_types.h */; };
-		C68C6209130FFE7E00F16728 /* namespace.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6201130FFE7E00F16728 /* namespace.h */; };
+		C68C6208130FFE7E00F16728 /* namespace_types.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6200130FFE7E00F16728 /* namespace_types.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C68C6209130FFE7E00F16728 /* namespace.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6201130FFE7E00F16728 /* namespace.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C68C620A130FFE7E00F16728 /* quota_parser.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6202130FFE7E00F16728 /* quota_parser.h */; };
 		C68C620B130FFE7E00F16728 /* quota_sender.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6203130FFE7E00F16728 /* quota_sender.h */; };
-		C68C620C130FFE7E00F16728 /* quota_types.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6204130FFE7E00F16728 /* quota_types.h */; };
-		C68C620D130FFE7E00F16728 /* quota.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6205130FFE7E00F16728 /* quota.h */; };
+		C68C620C130FFE7E00F16728 /* quota_types.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6204130FFE7E00F16728 /* quota_types.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C68C620D130FFE7E00F16728 /* quota.h in Headers */ = {isa = PBXBuildFile; fileRef = C68C6205130FFE7E00F16728 /* quota.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C69AB0411054298E00F32FBD /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = C69AAFB51054298E00F32FBD /* config.h */; settings = {ATTRIBUTES = (); }; };
 		C69AB1981054704000F32FBD /* acl.c in Sources */ = {isa = PBXBuildFile; fileRef = C6F9E9EE105335BC0059C3BA /* acl.c */; };
 		C69AB19A1054704000F32FBD /* acl_parser.c in Sources */ = {isa = PBXBuildFile; fileRef = C6F9E9F0105335BC0059C3BA /* acl_parser.c */; };
@@ -522,7 +527,6 @@
 		C69AB2DE1054704000F32FBD /* uidplus_types.c in Sources */ = {isa = PBXBuildFile; fileRef = C6F9EA21105335BC0059C3BA /* uidplus_types.c */; };
 		C69AD25F14AB2062003D04D5 /* xgmlabels.c in Sources */ = {isa = PBXBuildFile; fileRef = C6CE9B1514AA9C8900D20BA6 /* xgmlabels.c */; };
 		C6CE9B1614AA9C8B00D20BA6 /* xgmlabels.c in Sources */ = {isa = PBXBuildFile; fileRef = C6CE9B1514AA9C8900D20BA6 /* xgmlabels.c */; };
-		C6CE9B1914AA9C9D00D20BA6 /* xgmlabels.h in Headers */ = {isa = PBXBuildFile; fileRef = C6CE9B1814AA9C9C00D20BA6 /* xgmlabels.h */; };
 		C6DC671C1083CDA000FA050B /* acl.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DC66931083CDA000FA050B /* acl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C6DC671D1083CDA000FA050B /* acl_types.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DC66941083CDA000FA050B /* acl_types.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C6DC671E1083CDA000FA050B /* annotatemore.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DC66951083CDA000FA050B /* annotatemore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -859,6 +863,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		365DFFD115D1C93100F2DD85 /* xgmmsgid.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = xgmmsgid.c; sourceTree = "<group>"; };
+		365DFFD815D1CF1800F2DD85 /* xgmmsgid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = xgmmsgid.h; sourceTree = "<group>"; };
+		365DFFDA15D1CF6D00F2DD85 /* xgmmsgid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = xgmmsgid.h; sourceTree = "<group>"; };
+		365DFFDE15D1F2F800F2DD85 /* mailstream_cfstream.h */ = {isa = PBXFileReference; lastKnownFileType = file; name = mailstream_cfstream.h; path = include/libetpan/mailstream_cfstream.h; sourceTree = "<group>"; };
+		365DFFE015D1F35800F2DD85 /* quota.h */ = {isa = PBXFileReference; lastKnownFileType = file; name = quota.h; path = include/libetpan/quota.h; sourceTree = "<group>"; };
+		365DFFE115D1F37C00F2DD85 /* quota_types.h */ = {isa = PBXFileReference; lastKnownFileType = file; name = quota_types.h; path = include/libetpan/quota_types.h; sourceTree = "<group>"; };
+		365DFFE215D1F3A300F2DD85 /* namespace_types.h */ = {isa = PBXFileReference; lastKnownFileType = file; name = namespace_types.h; path = include/libetpan/namespace_types.h; sourceTree = "<group>"; };
+		365DFFE315D1F3A300F2DD85 /* namespace.h */ = {isa = PBXFileReference; lastKnownFileType = file; name = namespace.h; path = include/libetpan/namespace.h; sourceTree = "<group>"; };
+		365DFFE415D1F3CD00F2DD85 /* xgmlabels.h */ = {isa = PBXFileReference; lastKnownFileType = file; name = xgmlabels.h; path = include/libetpan/xgmlabels.h; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* libetpan.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = libetpan.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6516B69130DD667004ADD56 /* namespace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = namespace.h; sourceTree = "<group>"; };
@@ -1416,6 +1429,12 @@
 		0867D691FE84028FC02AAC07 /* libetpan */ = {
 			isa = PBXGroup;
 			children = (
+				365DFFE415D1F3CD00F2DD85 /* xgmlabels.h */,
+				365DFFE215D1F3A300F2DD85 /* namespace_types.h */,
+				365DFFE315D1F3A300F2DD85 /* namespace.h */,
+				365DFFE115D1F37C00F2DD85 /* quota_types.h */,
+				365DFFE015D1F35800F2DD85 /* quota.h */,
+				365DFFDE15D1F2F800F2DD85 /* mailstream_cfstream.h */,
 				08FB77AEFE84172EC02AAC07 /* libetpan */,
 				32C88DFF0371C24200C91783 /* Other Sources */,
 				089C1665FE841158C02AAC07 /* Resources */,
@@ -1618,6 +1637,7 @@
 				C6DC67191083CDA000FA050B /* pop3storage.h */,
 				C6DC671A1083CDA000FA050B /* uidplus.h */,
 				C6DC671B1083CDA000FA050B /* uidplus_types.h */,
+				365DFFDA15D1CF6D00F2DD85 /* xgmmsgid.h */,
 			);
 			path = libetpan;
 			sourceTree = "<group>";
@@ -2074,6 +2094,8 @@
 				C6667DEE1342ACCD00969A8E /* xlist.h */,
 				C6CE9B1514AA9C8900D20BA6 /* xgmlabels.c */,
 				C6CE9B1814AA9C9C00D20BA6 /* xgmlabels.h */,
+				365DFFD115D1C93100F2DD85 /* xgmmsgid.c */,
+				365DFFD815D1CF1800F2DD85 /* xgmmsgid.h */,
 			);
 			path = imap;
 			sourceTree = "<group>";
@@ -2325,6 +2347,7 @@
 				C6DC67761083CDA000FA050B /* mailsmtp_types.h in Headers */,
 				C6DC67771083CDA000FA050B /* mailstorage.h in Headers */,
 				C6DC67781083CDA000FA050B /* mailstorage_types.h in Headers */,
+				365DFFDF15D1F2F800F2DD85 /* mailstream_cfstream.h in Headers */,
 				C6DC67791083CDA000FA050B /* mailstream.h in Headers */,
 				C6DC677A1083CDA000FA050B /* mailstream_helper.h in Headers */,
 				C6DC677B1083CDA000FA050B /* mailstream_low.h in Headers */,
@@ -2346,6 +2369,8 @@
 				C6DC678B1083CDA000FA050B /* mhdriver_types.h in Headers */,
 				C6DC678C1083CDA000FA050B /* mhstorage.h in Headers */,
 				C6DC678D1083CDA000FA050B /* mime_message_driver.h in Headers */,
+				C68C6208130FFE7E00F16728 /* namespace_types.h in Headers */,
+				C68C6209130FFE7E00F16728 /* namespace.h in Headers */,
 				C6DC678E1083CDA000FA050B /* mmapstring.h in Headers */,
 				C6DC678F1083CDA000FA050B /* newsfeed.h in Headers */,
 				C6DC67901083CDA000FA050B /* newsfeed_item.h in Headers */,
@@ -2366,8 +2391,12 @@
 				C6DC679F1083CDA000FA050B /* pop3driver_cached_message.h in Headers */,
 				C6DC67A01083CDA000FA050B /* pop3driver_message.h in Headers */,
 				C6DC67A11083CDA000FA050B /* pop3driver_types.h in Headers */,
+				C68C620C130FFE7E00F16728 /* quota_types.h in Headers */,
+				C68C620D130FFE7E00F16728 /* quota.h in Headers */,
 				C6DC67A21083CDA000FA050B /* pop3storage.h in Headers */,
+				365DFFE515D1F3CD00F2DD85 /* xgmlabels.h in Headers */,
 				C6DC67A31083CDA000FA050B /* uidplus.h in Headers */,
+				365DFFDB15D1CF6D00F2DD85 /* xgmmsgid.h in Headers */,
 				C6DC67A41083CDA000FA050B /* uidplus_types.h in Headers */,
 				C6451AFE1083D316003135FD /* mailimf_write.h in Headers */,
 				C6451AFF1083D316003135FD /* mhdriver_cached.h in Headers */,
@@ -2558,15 +2587,11 @@
 				C6517A0D130E86D3004ADD56 /* namespace_sender.h in Headers */,
 				C68C6206130FFE7E00F16728 /* namespace_parser.h in Headers */,
 				C68C6207130FFE7E00F16728 /* namespace_sender.h in Headers */,
-				C68C6208130FFE7E00F16728 /* namespace_types.h in Headers */,
-				C68C6209130FFE7E00F16728 /* namespace.h in Headers */,
 				C68C620A130FFE7E00F16728 /* quota_parser.h in Headers */,
 				C68C620B130FFE7E00F16728 /* quota_sender.h in Headers */,
-				C68C620C130FFE7E00F16728 /* quota_types.h in Headers */,
-				C68C620D130FFE7E00F16728 /* quota.h in Headers */,
 				C6667DF01342ACCD00969A8E /* xlist.h in Headers */,
 				C6EFB8791433F1F300F805C0 /* mailstream_cfstream.h in Headers */,
-				C6CE9B1914AA9C9D00D20BA6 /* xgmlabels.h in Headers */,
+				365DFFD915D1CF1800F2DD85 /* xgmmsgid.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2843,8 +2868,9 @@
 				C6517A08130E86C6004ADD56 /* namespace_types.c in Sources */,
 				C6517A0E130E86D3004ADD56 /* namespace_sender.c in Sources */,
 				C6667DEF1342ACCD00969A8E /* xlist.c in Sources */,
-				C6EFB8781433F1F300F805C0 /* mailstream_cfstream.c in Sources */,
 				C6CE9B1614AA9C8B00D20BA6 /* xgmlabels.c in Sources */,
+				365DFFD215D1C93100F2DD85 /* xgmmsgid.c in Sources */,
+				C6EFB8781433F1F300F805C0 /* mailstream_cfstream.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3189,6 +3215,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -3198,7 +3225,7 @@
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(HOME)/Library/Frameworks";
+				INSTALL_PATH = "@loader_path/../Frameworks";
 				PRODUCT_NAME = libetpan;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
@@ -3209,15 +3236,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				GCC_MODEL_TUNING = G5;
 				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(HOME)/Library/Frameworks";
+				INSTALL_PATH = "@loader_path/../Frameworks";
 				PRODUCT_NAME = libetpan;
 				SDKROOT = macosx;
+				STRIP_INSTALLED_PRODUCT = YES;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;

--- a/src/low-level/imap/Makefile.am
+++ b/src/low-level/imap/Makefile.am
@@ -42,7 +42,7 @@ etpaninclude_HEADERS = \
 	quota.h quota_parser.h quota_sender.h quota_types.h \
 	idle.h \
 	namespace.h namespace_parser.h namespace_sender.h namespace_types.h \
-	xlist.h xgmlabels.h
+	xlist.h xgmlabels.h xgmmsgid.h
 
 AM_CPPFLAGS = -I$(top_builddir)/include \
 	-I$(top_srcdir)/src/data-types
@@ -82,4 +82,5 @@ libimap_la_SOURCES = \
 	namespace_sender.c namespace_sender.h \
 	namespace_types.c namespace_types.h \
 	xlist.c xlist.h \
-	xgmlabels.c xgmlabels.h
+	xgmlabels.c xgmlabels.h \
+        xgmmsgid.c xgmmsgid.h

--- a/src/low-level/imap/mailimap_extension.c
+++ b/src/low-level/imap/mailimap_extension.c
@@ -47,6 +47,7 @@
 #include "namespace.h"
 #include "xlist.h"
 #include "xgmlabels.h"
+#include "xgmmsgid.h"
 
 /*
   the list of registered extensions (struct mailimap_extension_api *)
@@ -64,6 +65,7 @@ static struct mailimap_extension_api * internal_extension_list[] = {
   &mailimap_extension_namespace,
   &mailimap_extension_xlist,
   &mailimap_extension_xgmlabels,
+  &mailimap_extension_xgmmsgid
 };
 
 LIBETPAN_EXPORT

--- a/src/low-level/imap/mailimap_extension_types.h
+++ b/src/low-level/imap/mailimap_extension_types.h
@@ -14,7 +14,8 @@ enum {
   MAILIMAP_EXTENSION_QUOTA,         /* quota */
   MAILIMAP_EXTENSION_NAMESPACE,     /* namespace */
   MAILIMAP_EXTENSION_XLIST,         /* XLIST (Gmail and Zimbra have this) */
-  MAILIMAP_EXTENSION_XGMLABELS      /* X-GM-LABELS (Gmail) */
+  MAILIMAP_EXTENSION_XGMLABELS,     /* X-GM-LABELS (Gmail) */
+  MAILIMAP_EXTENSION_XGMMSGID       /* X-GM-MSGID (Gmail) */
 };
 
 

--- a/src/low-level/imap/xgmmsgid.c
+++ b/src/low-level/imap/xgmmsgid.c
@@ -1,0 +1,199 @@
+#include "xgmmsgid.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "clist.h"
+#include "mailimap_types_helper.h"
+#include "mailimap_extension.h"
+#include "mailimap_keywords.h"
+#include "mailimap_parser.h"
+#include "mailimap_sender.h"
+#include "mailimap.h"
+
+enum {
+    MAILIMAP_XGMMSGID_TYPE_MSGID
+};
+
+static int
+mailimap_xgmmsgid_extension_parse(int calling_parser, mailstream * fd,
+                                   MMAPString * buffer, size_t * indx,
+                                   struct mailimap_extension_data ** result,
+                                   size_t progr_rate, progress_function * progr_fun);
+
+static void
+mailimap_xgmmsgid_extension_data_free(struct mailimap_extension_data * ext_data);
+
+LIBETPAN_EXPORT
+struct mailimap_extension_api mailimap_extension_xgmmsgid = {
+    /* name */          "X-GM-MSGID",
+    /* extension_id */  MAILIMAP_EXTENSION_XGMMSGID,
+    /* parser */        mailimap_xgmmsgid_extension_parse,
+    /* free */          mailimap_xgmmsgid_extension_data_free
+};
+
+static int fetch_data_xgmmsgid_parse(mailstream * fd,
+                                      MMAPString * buffer, size_t * indx,
+                                      uint64_t * result, size_t progr_rate, progress_function * progr_fun)
+{
+    size_t cur_token;
+    uint64_t msgid;
+    uint32_t uid;
+    char  *msgid_str;
+    int r;
+    
+    cur_token = * indx;
+    
+    r = mailimap_number_parse(fd, buffer, &cur_token, &uid);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+
+    r = mailimap_space_parse(fd, buffer, &cur_token);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    r = mailimap_token_case_insensitive_parse(fd, buffer,
+                                              &cur_token, "FETCH");
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+
+    r = mailimap_space_parse(fd, buffer, &cur_token);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    r = mailimap_token_case_insensitive_parse(fd, buffer,
+                                              &cur_token, "X-GM-MSGID");
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    r = mailimap_space_parse(fd, buffer, &cur_token);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    r = mailimap_astring_parse(fd, buffer, &cur_token, &msgid_str, progr_rate, progr_fun);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    msgid = atol(msgid_str);
+    
+    r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    * indx = cur_token;
+    * result = msgid;
+    
+    return MAILIMAP_NO_ERROR;
+}
+
+static int
+mailimap_xgmmsgid_extension_parse(int calling_parser, mailstream * fd,
+                                   MMAPString * buffer, size_t * indx,
+                                   struct mailimap_extension_data ** result,
+                                   size_t progr_rate, progress_function * progr_fun)
+{
+    size_t cur_token;
+    uint64_t msgid;
+    struct mailimap_extension_data * ext_data;
+    int r;
+    
+    cur_token = * indx;
+    
+    switch (calling_parser)
+    {
+        case MAILIMAP_EXTENDED_PARSER_MAILBOX_DATA:
+            
+            r = fetch_data_xgmmsgid_parse(fd, buffer, &cur_token, &msgid, progr_rate, progr_fun);
+            if (r != MAILIMAP_NO_ERROR)
+              return r;
+                                
+            ext_data = mailimap_extension_data_new(&mailimap_extension_xgmmsgid,
+                                                   MAILIMAP_XGMMSGID_TYPE_MSGID, &msgid);
+            if (ext_data == NULL) {
+                return MAILIMAP_ERROR_MEMORY;
+            }
+            
+            * result = ext_data;
+            * indx = cur_token;
+            
+            return MAILIMAP_NO_ERROR;
+            
+        default:
+            return MAILIMAP_ERROR_PARSE;
+    }
+}
+
+static void
+mailimap_xgmmsgid_extension_data_free(struct mailimap_extension_data * ext_data)
+{
+    if (ext_data == NULL)
+        return;
+ 
+    free(ext_data);
+}
+
+int mailimap_fetch_xgmmsgid(mailimap * session,
+                            struct mailimap_set * set,
+                            clist ** results)
+{
+    struct mailimap_response * response;
+    int r;
+    int error_code;
+    
+    if (session->imap_state != MAILIMAP_STATE_SELECTED)
+        return MAILIMAP_ERROR_BAD_STATE;
+    
+    r = mailimap_send_current_tag(session);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    r = mailimap_token_send(session->imap_stream, "FETCH");
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    r = mailimap_space_send(session->imap_stream);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    r = mailimap_set_send(session->imap_stream, set);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    r = mailimap_space_send(session->imap_stream);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    r = mailimap_token_send(session->imap_stream, "(X-GM-MSGID)");
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    r = mailimap_crlf_send(session->imap_stream);
+    if (r != MAILIMAP_NO_ERROR)
+      return r;
+    
+    if (mailstream_flush(session->imap_stream) == -1)
+        return MAILIMAP_ERROR_STREAM;
+    
+    if (mailimap_read_line(session) == NULL)
+        return MAILIMAP_ERROR_STREAM;
+   
+    r = mailimap_parse_response(session, &response);
+    if (r != MAILIMAP_NO_ERROR)
+        return r;
+    
+    error_code = response->rsp_resp_done->rsp_data.rsp_tagged->rsp_cond_state->rsp_type;
+    
+    *results = response->rsp_cont_req_or_resp_data_list;
+
+    mailimap_response_free(response);
+    
+    switch (error_code) {
+        case MAILIMAP_RESP_COND_STATE_OK:
+            return MAILIMAP_NO_ERROR;
+            
+        default:
+            return MAILIMAP_ERROR_FETCH;
+    }
+}

--- a/src/low-level/imap/xgmmsgid.h
+++ b/src/low-level/imap/xgmmsgid.h
@@ -1,0 +1,25 @@
+#ifndef XGMMSGID_H
+#define XGMMSGID_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
+#include <libetpan/libetpan-config.h>
+#include <libetpan/mailimap_extension.h>
+
+  LIBETPAN_EXPORT
+  extern struct mailimap_extension_api mailimap_extension_xgmmsgid;
+  
+  LIBETPAN_EXPORT
+  int
+  mailimap_fetch_xgmmsgid(mailimap * session,
+                          struct mailimap_set * set,
+                          clist ** results);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif


### PR DESCRIPTION
I have a version that uses hex strings for the msg id instead of 64-bit unsigned longs. I find it less tedious to work with the hex string but you may want to keep this commit in the library as it is more general. I will push that commit soon. 

I also have implemented "raw search" functionality so you can retrieve a list of UIDs belonging to messages  that match the search query.
