### PR TITLE
Release resources when closing gnutls session

### DIFF
--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -605,9 +605,12 @@ static void  ssl_data_close(struct mailstream_ssl_data * ssl_data)
 {
   gnutls_certificate_free_credentials(ssl_data->xcred);
   gnutls_deinit(ssl_data->session);
+
   MUTEX_LOCK(&ssl_lock);
-  gnutls_global_deinit();
+  if(!gnutls_init_not_required)
+    gnutls_global_deinit();
   MUTEX_UNLOCK(&ssl_lock);
+
   ssl_data->session = NULL;
 #ifdef WIN32
   closesocket(socket_data->fd);


### PR DESCRIPTION
When a gnutls session is initiated (`mailstream_ssl.c:258`), there is a call to `gnutls_global_init()` (`mailstream_ssl.c:278`) but no call to `gnutls_global_deinit()` which is required in order to release resources by the gnutls session structures.

`gnutls_global_init()` increments a global counter, and `gnutls_global_deinit()` decrements this counter, so resources only get released when `gnutls_global_deinit()` is called as many times as `gnutls_global_init()`.

It should be noted that `gnutls_global_deinit()` is not thread-safe, hence the locking around it.
