### PR TITLE
Default Xcode project to 2-space indentation

### DIFF
--- a/build-mac/libetpan.xcodeproj/project.pbxproj
+++ b/build-mac/libetpan.xcodeproj/project.pbxproj
@@ -1461,8 +1461,11 @@
 				0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */,
 				034768DFFF38A50411DB9C8B /* Products */,
 			);
+			indentWidth = 2;
 			name = libetpan;
 			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
 		};
 		0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
The code seems to use 2 spaces for indentation; setting that in the Xcode project means it will default to that for everyone (for that project).
