### PR TITLE
Adding OAuth2 authentication support

### DIFF
--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -1851,6 +1851,61 @@ int mailimap_authenticate(mailimap * session, const char * auth_type,
 #endif
 }
 
+LIBETPAN_EXPORT
+int mailimap_oauth2_authenticate(mailimap * session, const char *auth_user, const char * access_token)
+{
+  struct mailimap_response * response;
+  int r;
+  int error_code;
+  
+  if (session->imap_state != MAILIMAP_STATE_NON_AUTHENTICATED)
+    return MAILIMAP_ERROR_BAD_STATE;
+  
+  mailstream_set_privacy(session->imap_stream, 0);
+  r = mailimap_send_current_tag(session);
+  if (r != MAILIMAP_NO_ERROR) {
+    mailstream_set_privacy(session->imap_stream, 1);
+    return r;
+  }
+  
+  r = mailimap_oauth2_authenticate_send(session, auth_user, access_token);
+  if (r != MAILIMAP_NO_ERROR) {
+    mailstream_set_privacy(session->imap_stream, 1);
+    return r;
+  }
+  
+  r = mailimap_crlf_send(session->imap_stream);
+  if (r != MAILIMAP_NO_ERROR) {
+    mailstream_set_privacy(session->imap_stream, 1);
+    return r;
+  }
+  
+  if (mailstream_flush(session->imap_stream) == -1) {
+    mailstream_set_privacy(session->imap_stream, 1);
+    return MAILIMAP_ERROR_STREAM;
+  }
+  mailstream_set_privacy(session->imap_stream, 1);
+  
+  if (mailimap_read_line(session) == NULL)
+    return MAILIMAP_ERROR_STREAM;
+  
+  r = mailimap_parse_response(session, &response);
+  if (r != MAILIMAP_NO_ERROR)
+    return r;
+  
+  error_code = response->rsp_resp_done->rsp_data.rsp_tagged->rsp_cond_state->rsp_type;
+  
+  mailimap_response_free(response);
+  
+  switch (error_code) {
+    case MAILIMAP_RESP_COND_STATE_OK:
+      session->imap_state = MAILIMAP_STATE_AUTHENTICATED;
+      return MAILIMAP_NO_ERROR;
+      
+    default:
+      return MAILIMAP_ERROR_LOGIN;
+  }
+}
 
 LIBETPAN_EXPORT
 int mailimap_lsub(mailimap * session, const char * mb,

--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -394,6 +394,50 @@ int mailimap_authenticate(mailimap * session, const char * auth_type,
     const char * login, const char * auth_name,
     const char * password, const char * realm);
 
+/*
+   mailimap_oauth2_authenticate()
+   Authenticates the client using using an oauth2 token.
+   To gather a deeper understanding of the OAuth2 aunthentication
+   process refer to: https://developers.google.com/gmail/xoauth2_protocol
+   For a quick start you may follow this brief set of steps:
+   1. Set up a profile for your app in the Google 
+      API Console: https://code.google.com/apis/console
+   2. With your recently obtained client_id and secret 
+      load the following URL (everything goes ina single line):
+      https://accounts.google.com/o/oauth2/auth?client_id=[YOUR_CLIENT_ID]&
+          redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&
+          response_type=code&scope=https%3A%2F%2Fmail.google.com%2F&
+          login_hint=[USER_EMAIL_ADDRESS]&access_type=offline
+   3. The user most follow instructions to authorize application access
+      to Gmail.
+   4. After the user hits the "Accept" button it will be redirected to another
+      page where the access token will be issued.
+   5. Now from the app we need and authorization token, to get one we issue a POST request
+      the following URL: https://accounts.google.com/o/oauth2/token using these parameters:
+      client_id: This is the client id we got from step 1
+      client_secret: Client secret as we got it from step 1
+      code: This is the code we received in step 4
+      redirect_uri: This is a redirect URI where the access token will be sent, for non 
+       web applications this is usually urn:ietf:wg:oauth:2.0:oob (as we got from step 1)
+      grant_type: Always use the authorization_code parameter to retrieve an access and refresh tokens
+   6. After step 5 completes we receive a JSON object similar to:
+       {
+         "access_token":"1/fFAGRNJru1FTz70BzhT3Zg",
+         "refresh_token":"1/fFAGRNJrufoiWEGIWEFJFJF",
+         "expires_in":3920,
+         "token_type":"Bearer"
+       }
+      The access token is what we need to authenticate via XOAuth2 with Gmail.
+   @param session       IMAP session
+   @param session       Authentication user (tipically an e-mail address, depends on server)
+   @param access_token  OAuth2 access token
+   @return the return code is one of MAILIMAP_ERROR_XXX or
+   MAILIMAP_NO_ERROR codes
+  */
+LIBETPAN_EXPORT
+int mailimap_oauth2_authenticate(mailimap * session, const char *auth_user,
+    const char * access_token);
+
 
 /*
    mailimap_lsub()

--- a/src/low-level/imap/mailimap_sender.c
+++ b/src/low-level/imap/mailimap_sender.c
@@ -42,9 +42,11 @@
 #include "mailimap_sender.h"
 #include "clist.h"
 #include "mail.h"
+#include "base64.h"
 #include <string.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 
 /*
@@ -468,6 +470,47 @@ int mailimap_authenticate_resp_send(mailstream * fd,
     return r;
   
   return MAILIMAP_NO_ERROR;
+}
+
+int mailimap_oauth2_authenticate_send(mailimap * session,
+                                      const char *auth_user,
+                                      const char * access_token)
+{
+  int r;
+  char *ptr;
+  //Build client response string
+  char *full_auth_string, *full_auth_string_b64;
+  int auth_user_len, access_token_len, full_auth_string_len;
+  auth_user_len = strlen(auth_user);
+  access_token_len = strlen(access_token);
+  full_auth_string_len = 5 + auth_user_len + 1 + 12 + access_token_len + 2;
+  full_auth_string = (char *)malloc(full_auth_string_len + 1);
+  if (full_auth_string == NULL) {
+    return MAILIMAP_ERROR_MEMORY;
+  }
+  ptr = memcpy(full_auth_string, "user=", 5);
+  ptr = memcpy(ptr + 5, auth_user, auth_user_len);
+  ptr = memcpy(ptr + auth_user_len, "\1auth=Bearer ", 13);
+  ptr = memcpy(ptr + 13, access_token, access_token_len);
+  ptr = memcpy(ptr + access_token_len, "\1\1\0", 3);
+  //Convert to base64
+  full_auth_string_b64 = encode_base64(full_auth_string, full_auth_string_len);
+  
+  r = mailimap_token_send(session->imap_stream, "AUTHENTICATE");
+  if (r != MAILIMAP_NO_ERROR)
+    return r;
+  r = mailimap_space_send(session->imap_stream);
+  if (r != MAILIMAP_NO_ERROR)
+    return r;
+  r = mailimap_token_send(session->imap_stream, "XOAUTH2");
+  if (r != MAILIMAP_NO_ERROR)
+    return r;
+  r = mailimap_space_send(session->imap_stream);
+  if (r != MAILIMAP_NO_ERROR)
+    return r;
+  r = mailimap_astring_send(session->imap_stream, full_auth_string_b64);
+  free(full_auth_string_b64);
+  return r;
 }
 
 /*

--- a/src/low-level/imap/mailimap_sender.h
+++ b/src/low-level/imap/mailimap_sender.h
@@ -55,6 +55,11 @@ int mailimap_authenticate_send(mailstream * fd,
 int mailimap_authenticate_resp_send(mailstream * fd,
 				const char * base64);
 
+int mailimap_oauth2_authenticate_send(mailimap * session,
+				const char *auth_user,
+				const char * access_token);
+
+
 int mailimap_noop_send(mailstream * fd);
 
 int mailimap_logout_send(mailstream * fd);


### PR DESCRIPTION
Implements two functions:
mailimap_oauth2_authenticate: Use to to send the authentication token
to the server and actually authenticate with it.
mailimap_oauth2_authenticate_send Builds and sends the authentication
string in the form of base64("user=" {User} "^Aauth=Bearer " {Access
Token} "^A^A")`
This has been tested against Gmail.
