### PR TITLE
Support Xcode in non-standard locations.

### DIFF
--- a/build-mac/dependencies/prepare-cyrus-sasl.sh
+++ b/build-mac/dependencies/prepare-cyrus-sasl.sh
@@ -114,7 +114,8 @@ INSTALL_PATH=${BUILD_DIR}/${LIB_NAME}/universal
 
 for TARGET in $TARGETS; do
 
-    TOOLCHAIN=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
+    DEVELOPER=$(xcode-select --print-path)
+    TOOLCHAIN="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin"
     SYSROOT=`xcodebuild -version -sdk 2>/dev/null | egrep $TARGET -B 3 | egrep '^Path: '| egrep $SDK_IOS_VERSION | sort -u | tail -n 1| cut -d ' ' -f 2`
 
     case $TARGET in


### PR DESCRIPTION
Use xcode-select --print-path to find the currently selected Xcode.
This avoids hardcoding /Applications/Xcode.app, so that it is
possible to use Xcode from non-standard locations (I have Xcode4
and Xcode5 installed in parallel).

Note that it is not possible to have Xcode installed in a path
with a space (I used "Xcode 5" originally).  I tried to fix this
but it looks like sasl's configure and build would never manage it.
