### PR TITLE
Fix crash where uninitialized password is freed.

### DIFF
--- a/src/driver/implementation/imap/imapstorage.c
+++ b/src/driver/implementation/imap/imapstorage.c
@@ -276,10 +276,14 @@ int imap_mailstorage_init_sasl_with_local_address(struct mailstorage * storage,
   else {
     imap_storage->imap_login = NULL;
   }
+
   if (imap_storage->imap_sasl.sasl_password != NULL) {
     imap_storage->imap_password = strdup(imap_storage->imap_sasl.sasl_password);
     if (imap_storage->imap_password == NULL)
       goto free_copy_login;
+  }
+  else {
+    imap_storage->imap_password = NULL;
   }
   
   storage->sto_data = imap_storage;


### PR DESCRIPTION
Inside imap_mailstorage_init_sasl_with_local_address,
imap_storage->imap_password was only initialized if the password
parameter was set.  This meant that we would crash in
imap_mailstorage_uninitialize when attempting to free the
uninitialized value.
