### PR TITLE
wipe off an error report in gyp/gcc

### DIFF
--- a/src/data-types/connect.c
+++ b/src/data-types/connect.c
@@ -91,7 +91,7 @@ static int prepare_fd(int fd)
 #ifdef HAVE_IPV6
 static int verify_sock_errors(int s)
 {
-  unsigned int len;
+  socklen_t len;
   int val;
   len = sizeof(val);
   if (getsockopt(s, SOL_SOCKET, SO_ERROR, &val, &len) < 0) {


### PR DESCRIPTION
I got a error from `gyp`, that tell me the `uint` is uncleared, is this a typo?
