### PR TITLE
remove duplicate calls

### DIFF
--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -270,9 +270,7 @@ static inline void mailstream_ssl_init(void)
     
     SSL_load_error_strings();
     SSL_library_init();
-    OpenSSL_add_all_digests();
     OpenSSL_add_all_algorithms();
-    OpenSSL_add_all_ciphers();
     
     openssl_init_done = 1;
   }


### PR DESCRIPTION
> OpenSSL_add_all_algorithms() adds all algorithms to the table (digests and ciphers).

Then `OpenSSL_add_all_digests` and `OpenSSL_add_all_ciphers` are unnecessary.
