### PR TITLE
use `SSL_MODE_RELEASE_BUFFERS` to save memory

### DIFF
--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -411,6 +411,12 @@ static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
   SSL_CTX_set_app_data(tmp_ctx, ssl_context);
   SSL_CTX_set_client_cert_cb(tmp_ctx, mailstream_openssl_client_cert_cb);
   ssl_conn = (SSL *) SSL_new(tmp_ctx);
+  
+#ifdef SSL_MODE_RELEASE_BUFFERS
+  long mode = SSL_get_mode(ssl_conn);
+  SSL_set_mode(ssl_conn, mode | SSL_MODE_RELEASE_BUFFERS);
+#endif
+  
   if (ssl_conn == NULL)
     goto free_ctx;
   


### PR DESCRIPTION
> ### SSL_MODE_RELEASE_BUFFERS
> 
> When we no longer need a read buffer or a write buffer for a given SSL, then release the memory we were using to hold it. Released memory is either appended to a list of unused RAM chunks on the SSL_CTX, or simply freed if the list of unused chunks would become longer than SSL_CTX->freelist_max_len, which defaults to 32. Using this flag can save around 34k per idle SSL connection. This flag has no effect on SSL v2 connections, or on DTLS connections.

For more details, you could visit: https://www.openssl.org/docs/ssl/SSL_CTX_set_mode.html
