### PR TITLE
fix `Undefined symbols` without `HAVE_ZLIB`

### DIFF
--- a/src/data-types/mailstream_compress.c
+++ b/src/data-types/mailstream_compress.c
@@ -41,9 +41,17 @@
 
 #if !HAVE_ZLIB
 
+mailstream_low_driver * mailstream_compress_driver;
 mailstream_low * mailstream_low_compress_open(mailstream_low * ms)
 {
   return NULL;
+}
+
+int mailstream_low_compress_wait_idle(mailstream_low * low,
+                                      struct mailstream_cancel * idle,
+                                      int max_idle_delay)
+{
+  return mailstream_low_wait_idle(low, idle, max_idle_delay);
 }
 
 #else


### PR DESCRIPTION
In current version of this library, disable zlib could not pass the ld. Error trace:

```
Undefined symbols for architecture x86_64:
  "_mailstream_compress_driver", referenced from:
      _mailstream_low_wait_idle in libetpan.a(mailstream_low.o)
  "_mailstream_low_compress_wait_idle", referenced from:
      _mailstream_low_wait_idle in libetpan.a(mailstream_low.o)
ld: symbol(s) not found for architecture x86_64
```
