### PR TITLE
fix #637 update mail-smtp send command calls 

### DIFF
--- a/src/low-level/smtp/mailsmtp_oauth2.c
+++ b/src/low-level/smtp/mailsmtp_oauth2.c
@@ -73,68 +73,100 @@ static int oauth2_authenticate(mailsmtp * session, int type, const char * auth_u
   switch (type) {
     case XOAUTH2_TYPE_GMAIL:
     default:
-      snprintf(command, SMTP_STRING_SIZE, "AUTH XOAUTH2 %s\r\n", full_auth_string_b64);
+    {
+      snprintf(command, SMTP_STRING_SIZE, "AUTH XOAUTH2 ");
+      r = mailsmtp_send_command(session, command);
+      if (r == -1) {
+        res = MAILSMTP_ERROR_STREAM;
+        goto free;
+      }
+      r = mailsmtp_send_command(session, full_auth_string_b64);
+      if (r == -1) {
+        res = MAILSMTP_ERROR_STREAM;
+        goto free;
+      }
+      snprintf(command, SMTP_STRING_SIZE, "\r\n");
+      r = mailsmtp_send_command(session, command);
+      if (r == -1) {
+        res = MAILSMTP_ERROR_STREAM;
+        goto free;
+      }
       break;
+    }
     case XOAUTH2_TYPE_OUTLOOK_COM:
       snprintf(command, SMTP_STRING_SIZE, "AUTH XOAUTH2\r\n");
+      r = mailsmtp_send_command(session, command);
+      if (r == -1) {
+        res = MAILSMTP_ERROR_STREAM;
+        goto free;
+      }
       break;
-  }
-  r = mailsmtp_send_command(session, command);
-  if (r == -1) {
-    res = MAILSMTP_ERROR_STREAM;
-    goto free;
   }
   
   r = mailsmtp_read_response(session);
   switch (r) {
-  case 220:
-  case 235:
-    res = MAILSMTP_NO_ERROR;
-    goto free;
-
-  case 334:
-    /* AUTH in progress */
-    
-    switch (type) {
-      case XOAUTH2_TYPE_GMAIL:
-      default:
-        /* There's probably an error, send an empty line as acknowledgement. */
-        snprintf(command, SMTP_STRING_SIZE, "\r\n");
-        break;
-      case XOAUTH2_TYPE_OUTLOOK_COM:
-        snprintf(command, SMTP_STRING_SIZE, "%s\r\n", full_auth_string_b64);
-        break;
-    }
-    r = mailsmtp_send_command(session, command);
-    if (r == -1) {
-      res = MAILSMTP_ERROR_STREAM;
+    case 220:
+    case 235:
+      res = MAILSMTP_NO_ERROR;
       goto free;
-    }
-    
-    r = mailsmtp_read_response(session);
-    switch (r) {
-      case 535:
-        res = MAILSMTP_ERROR_AUTH_LOGIN;
-        goto free;
       
-      case 220:
-      case 235:
-        res = MAILSMTP_NO_ERROR;
-        goto free;
-        
-      default:
-        res = MAILSMTP_ERROR_UNEXPECTED_CODE;
-        goto free;
-    }
-    break;
-
-  default:
-    res = MAILSMTP_ERROR_UNEXPECTED_CODE;
-    goto free;
+    case 334:
+      /* AUTH in progress */
+      
+      switch (type) {
+        case XOAUTH2_TYPE_GMAIL:
+        default:
+        {
+          /* There's probably an error, send an empty line as acknowledgement. */
+          snprintf(command, SMTP_STRING_SIZE, "\r\n");
+          r = mailsmtp_send_command(session, command);
+          if (r == -1) {
+            res = MAILSMTP_ERROR_STREAM;
+            goto free;
+          }
+          break;
+        }
+        case XOAUTH2_TYPE_OUTLOOK_COM:
+        {
+          r = mailsmtp_send_command(session, full_auth_string_b64);
+          if (r == -1) {
+            res = MAILSMTP_ERROR_STREAM;
+            goto free;
+          }
+          snprintf(command, SMTP_STRING_SIZE, "\r\n");
+          r = mailsmtp_send_command(session, command);
+          if (r == -1) {
+            res = MAILSMTP_ERROR_STREAM;
+            goto free;
+          }
+          break;
+        }
+      }
+      
+      r = mailsmtp_read_response(session);
+      switch (r) {
+        case 535:
+          res = MAILSMTP_ERROR_AUTH_LOGIN;
+          goto free;
+          
+        case 220:
+        case 235:
+          res = MAILSMTP_NO_ERROR;
+          goto free;
+          
+        default:
+          res = MAILSMTP_ERROR_UNEXPECTED_CODE;
+          goto free;
+      }
+      break;
+      
+    default:
+      res = MAILSMTP_ERROR_UNEXPECTED_CODE;
+      goto free;
   }
   
-  free:
-   free(full_auth_string);
-   free(full_auth_string_b64);
-   return res;
+free:
+  free(full_auth_string);
+  free(full_auth_string_b64);
+  return res;
 }


### PR DESCRIPTION
update mail-smtp send command calls outlook & gmail to accommodate variable sized OAuth tokens
