### PR TITLE
Remove libraries not required/used with GnuTLS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,7 +228,7 @@ if test "x$with_gnutls" != "xno"; then
   fi
   GNUTLSLIB=""
   AC_CHECK_HEADER(gnutls/gnutls.h, [
-   AC_CHECK_LIB(gnutls, gnutls_global_deinit, with_gnutls=yes, [GNUTLSLIB="-lgnutls -lgcrypt -lgpg-error -lz"])
+   AC_CHECK_LIB(gnutls, gnutls_global_deinit, with_gnutls=yes, [GNUTLSLIB="-lgnutls"])
   ])
   if test "x$with_gnutls" != "xyes"; then
    CPPFLAGS="$OCPPFLAGS"


### PR DESCRIPTION
Based on Andreas Metzler's patch for libetpan Debian package:
http://anonscm.debian.org/gitweb/?p=users/mones/libetpan.git;a=blob;f=patches/10_unnecessary_linkage.diff;h=d1db5adb
