### PR TITLE
Fixed mailmime quoted printable write driver

### DIFF
--- a/src/low-level/mime/mailmime_write_generic.c
+++ b/src/low-level/mime/mailmime_write_generic.c
@@ -1323,7 +1323,6 @@ int mailmime_quoted_printable_write_driver(int (* do_write)(void *, const char *
             
           case '\r':
             state = STATE_CR;
-            len ++;
             i ++;
             break;
             


### PR DESCRIPTION
We shouldn't increment len here, because of 'case STATE_CR' appends \r.
