### PR TITLE
IMAP permanent flag parsing '\*' incorrectly.

### DIFF
--- a/src/low-level/imap/mailimap_parser.c
+++ b/src/low-level/imap/mailimap_parser.c
@@ -5661,16 +5661,17 @@ mailimap_flag_perm_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   type = MAILIMAP_FLAG_PERM_ERROR; /* XXX - removes a gcc warning */
   
-  r = mailimap_flag_parse(fd, buffer, &cur_token, &flag,
-			  progr_rate, progr_fun);
+  r = mailimap_token_case_insensitive_parse(fd, buffer,
+                                            &cur_token, "\\*");
   if (r == MAILIMAP_NO_ERROR)
-    type = MAILIMAP_FLAG_PERM_FLAG;
+    type = MAILIMAP_FLAG_PERM_ALL;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_token_case_insensitive_parse(fd, buffer,
-					      &cur_token, "\\*");
+    r = mailimap_flag_parse(fd, buffer, &cur_token, &flag,
+                            progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
-      type = MAILIMAP_FLAG_PERM_ALL;
+      type = MAILIMAP_FLAG_PERM_FLAG;
+
   }
 
   if (r != MAILIMAP_NO_ERROR) {


### PR DESCRIPTION
If the folders are allowed new flag to be created, the IMAP will include '*' in folder's permanent flags list. I found that libetpan is parsing incorrectly. It will return as a extension with '*' flag instead of MAILIMAP_FLAG_PERM_ALL flag.
