### PR TITLE
Moved function mailmime_param_new_with_data to mailmime_types_helper.c

### DIFF
--- a/src/engine/mailprivacy_tools.c
+++ b/src/engine/mailprivacy_tools.c
@@ -1221,36 +1221,6 @@ mailmime_content_dup(struct mailmime_content * content)
 }
 
 
-struct mailmime_parameter *
-mailmime_param_new_with_data(char * name, char * value)
-{
-  char * param_name;
-  char * param_value;
-  struct mailmime_parameter * param;
-
-  param_name = strdup(name);
-  if (param_name == NULL)
-    goto err;
-  
-  param_value = strdup(value);
-  if (param_value == NULL)
-    goto free_name;
-  
-  param = mailmime_parameter_new(param_name, param_value);
-  if (param == NULL)
-    goto free_value;
-  
-  return param;
-  
- free_value:
-  free(param_value);
- free_name:
-  free(param_name);
- err:
-  return NULL;
-}
-
-
 int mailprivacy_fetch_decoded_to_file(struct mailprivacy * privacy,
     char * filename, size_t size,
     mailmessage * msg, struct mailmime * mime)

--- a/src/engine/mailprivacy_tools.h
+++ b/src/engine/mailprivacy_tools.h
@@ -107,10 +107,6 @@ struct mailmime_content *
 mailmime_content_dup(struct mailmime_content * content);
 
 LIBETPAN_EXPORT
-struct mailmime_parameter *
-mailmime_param_new_with_data(char * name, char * value);
-
-LIBETPAN_EXPORT
 int mailprivacy_fetch_decoded_to_file(struct mailprivacy * privacy,
     char * filename, size_t size,
     mailmessage * msg, struct mailmime * mime);

--- a/src/low-level/mime/mailmime_types_helper.c
+++ b/src/low-level/mime/mailmime_types_helper.c
@@ -1396,3 +1396,32 @@ mailmime_data_new_file(int encoding, int encoded,
   return mailmime_data_new(MAILMIME_DATA_FILE, encoding, encoded, NULL, 0, filename);
 }
 
+
+struct mailmime_parameter *
+mailmime_param_new_with_data(char * name, char * value)
+{
+  char * param_name;
+  char * param_value;
+  struct mailmime_parameter * param;
+
+  param_name = strdup(name);
+  if (param_name == NULL)
+    goto err;
+  
+  param_value = strdup(value);
+  if (param_value == NULL)
+    goto free_name;
+  
+  param = mailmime_parameter_new(param_name, param_value);
+  if (param == NULL)
+    goto free_value;
+  
+  return param;
+  
+ free_value:
+  free(param_value);
+ free_name:
+  free(param_name);
+ err:
+  return NULL;
+}

--- a/src/low-level/mime/mailmime_types_helper.h
+++ b/src/low-level/mime/mailmime_types_helper.h
@@ -191,6 +191,10 @@ struct mailmime_fields * mailmime_fields_new_filename(int dsp_type,
     char * filename, int encoding_type);
 
 LIBETPAN_EXPORT
+struct mailmime_parameter *
+mailmime_param_new_with_data(char * name, char * value);
+
+LIBETPAN_EXPORT
 char * mailmime_generate_boundary(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
So function can be used in Windows without requiring engine files.
