### PR TITLE
kCFStreamPropertySSLPeerTrust fail on OS X<=10.8 - infinite loop

### DIFF
--- a/src/data-types/mailstream_cfstream.c
+++ b/src/data-types/mailstream_cfstream.c
@@ -1007,8 +1007,7 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
         }
     }
       
-    if (count == 0)
-    {
+    if (count == 0) {
       // No certificates, wait more.
       continue;
     }
@@ -1190,8 +1189,7 @@ static carray * mailstream_low_cfstream_get_certificate_chain(mailstream_low * s
       SecTrustEvaluate(secTrust, NULL);
       count = SecTrustGetCertificateCount(secTrust);
       result = carray_new(4);
-      for(i = 0 ; i < count ; i ++)
-      {
+      for(i = 0 ; i < count ; i ++) {
           SecCertificateRef cert = (SecCertificateRef) SecTrustGetCertificateAtIndex(secTrust, i);
           CFDataRef data = SecCertificateCopyData(cert);
           CFIndex length = CFDataGetLength(data);
@@ -1220,8 +1218,9 @@ static carray * mailstream_low_cfstream_get_certificate_chain(mailstream_low * s
           }
           CFRelease(certs);
       }
-      else
+      else {
           return NULL;
+      }
   }
     
   return result;


### PR DESCRIPTION
(following the #773 fix which caused a side effect on OS X <= 10.8 (maybe 10.9 too))
on OSX <= 10.8: the kCFStreamPropertySSLPeerTrust method works the first time, but always returns NULL after, causing an infinite loop. 

This change falls back to the old kCFStreamPropertySSLPeerCertificates method if the first one returns NULL.
On OSX 10.10, the first method always work.
