### PR TITLE
Fix potential null pointer dereferencing.

### DIFF
--- a/src/driver/tools/mailthread.c
+++ b/src/driver/tools/mailthread.c
@@ -245,6 +245,9 @@ static char * extract_subject(char * default_from,
   else
     subj = strdup(str);
 
+  if (subj == NULL)
+    return NULL;
+
   len = strlen(subj);
 
   /*


### PR DESCRIPTION
strdup can fail and return NULL pointer.