### PR TITLE
Missing boundary fix

### DIFF
--- a/src/low-level/mime/mailmime_content.c
+++ b/src/low-level/mime/mailmime_content.c
@@ -908,7 +908,11 @@ mailmime_multipart_body_parse(const char * message, size_t length,
       preamble_end --;
     }
   }
-  preamble_length = preamble_end - preamble_begin;
+  if (preamble_end > preamble_begin) {
+    preamble_length = preamble_end - preamble_begin;
+  } else {
+    preamble_length = 0;
+  }
   
   part_begin = cur_token;
   while (1) {

--- a/src/low-level/mime/mailmime_write_generic.c
+++ b/src/low-level/mime/mailmime_write_generic.c
@@ -81,6 +81,9 @@ static int mailmime_version_write_driver(int (* do_write)(void *, const char *, 
 static int mailmime_encoding_write_driver(int (* do_write)(void *, const char *, size_t), void * data, int * col,
 				   struct mailmime_mechanism * encoding);
 
+static int mailmime_location_write_driver(int (* do_write)(void *, const char *, size_t), void *data, int *col,
+                                   char *location);
+
 static int mailmime_language_write_driver(int (* do_write)(void *, const char *, size_t), void * data, int * col,
 				   struct mailmime_language * language);
 
@@ -167,6 +170,10 @@ static int mailmime_field_write_driver(int (* do_write)(void *, const char *, si
 
   case MAILMIME_FIELD_LANGUAGE:
     r = mailmime_language_write_driver(do_write, data, col, field->fld_data.fld_language);
+    break;
+
+  case MAILMIME_FIELD_LOCATION:
+    r = mailmime_location_write_driver(do_write, data, col, field->fld_data.fld_location);
     break;
 
   default:
@@ -307,6 +314,33 @@ static int mailmime_encoding_write_driver(int (* do_write)(void *, const char *,
   * col = 0;
 #endif
   
+  return MAILIMF_NO_ERROR;
+}
+
+static int mailmime_location_write_driver(int (* do_write)(void *, const char *, size_t), void *data, int *col,
+                                   char *location)
+{
+  int r;
+  int len = strlen(location);
+
+  r = mailimf_string_write_driver(do_write, data, col, "Content-Location: ", 18);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
+  if (*col > 1 && *col + len > MAX_MAIL_COL) {
+    r = mailimf_string_write_driver(do_write, data, col, "\r\n ", 3);
+    if (r != MAILIMF_NO_ERROR)
+      return r;
+  }
+
+  r = mailimf_string_write_driver(do_write, data, col, location, len);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
+  r = mailimf_string_write_driver(do_write, data, col, "\r\n", 2);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
   return MAILIMF_NO_ERROR;
 }
 


### PR DESCRIPTION
Hey, I've noticed a wrap-around issue in mailmime_multipart_body_parse() when parsing a broken multi-part mime-mail.

broken mail:
<pre>
Subject: Broken Mail
Mime-Version: 1.0
Content-Type: multipart/alternative;
        boundary="Apple-Mail=_DDA99EBE-980D-4F89-B1C1-959DBB87C6A5"

sometext
</pre>

