### PR TITLE
Detect extra data after STARTTLS responses in SMTP and POP3 and exit

### DIFF
--- a/src/low-level/pop3/mailpop3.c
+++ b/src/low-level/pop3/mailpop3.c
@@ -959,6 +959,14 @@ int mailpop3_stls(mailpop3 * f)
 
   if (r != RESPONSE_OK)
     return MAILPOP3_ERROR_STLS_NOT_SUPPORTED;
+
+  // Detect if the server send extra data after the STLS response.
+  // This *may* be a "response injection attack".
+  if (f->pop3_stream->read_buffer_len != 0) {
+    // Since it is also protocol violation, exit.
+    // There is no error type for STARTTLS errors in POP3
+    return MAILPOP3_ERROR_SSL;
+  }
   
   return MAILPOP3_NO_ERROR;
 }

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1111,6 +1111,14 @@ int mailesmtp_starttls(mailsmtp * session)
     return MAILSMTP_ERROR_STREAM;
   r = read_response(session);
 
+  // Detect if the server send extra data after the STARTTLS response.
+  // This *may* be a "response injection attack".
+  if (session->stream->read_buffer_len != 0) {
+    // Since it is also protocol violation, exit.
+    // There is no general error type for STARTTLS errors in SMTP
+    return MAILSMTP_ERROR_SSL;
+  }
+
   switch (r) {
   case 220:
     return MAILSMTP_NO_ERROR;


### PR DESCRIPTION
As promised, a pull request for Issue #386 in POP3 and SMTP. Note that there in no equivalent to MAILIMAP_ERROR_STARTTLS in SMTP and POP3, so I used the standard SSL errors.

I have not worked with libetpan before, so I have no idea what side effects these changes might cause. Handle with care.