### PR TITLE
Fix -Wundef build warnings

### DIFF
--- a/libetpan-config.h.in
+++ b/libetpan-config.h.in
@@ -6,7 +6,7 @@
 #define CONFIG_H
 #include "config.h"
 #endif
-@if WIN32
+@ifdef WIN32
 @	define MMAP_UNAVAILABLE
 @endif
 @if defined(_MSC_VER) && !defined(__cplusplus)

--- a/src/data-types/mailstream_ssl.h
+++ b/src/data-types/mailstream_ssl.h
@@ -45,7 +45,7 @@ extern "C" {
 
 /* socket */
 
-#if LIBETPAN_IOS_DISABLE_SSL
+#ifdef LIBETPAN_IOS_DISABLE_SSL
 #undef USE_SSL
 #endif
 


### PR DESCRIPTION
With `-Wundef` enabled I'm encountering build warnings like:
```
In file included from /usr/local/include/libetpan/libetpan.h:45:
In file included from /usr/local/include/libetpan/maildriver.h:40:
In file included from /usr/local/include/libetpan/maildriver_types.h:47:
In file included from /usr/local/include/libetpan/mailstream.h:44:
In file included from /usr/local/include/libetpan/mailstream_low.h:41:
In file included from /usr/local/include/libetpan/mailstream_types.h:46:
/usr/local/include/libetpan/libetpan-config.h:3:5: warning: 'WIN32' is not defined, evaluates to 0 [-Wundef]
#if WIN32
```
Similarly for `LIBETPAN_IOS_DISABLE_SSL`.