### PR TITLE
Prevent illegal memory access in remove_trailing_eol()

### DIFF
--- a/src/data-types/mailstream_helper.c
+++ b/src/data-types/mailstream_helper.c
@@ -44,11 +44,11 @@
 
 static void remove_trailing_eol(MMAPString * mmapstr)
 {
-  if (mmapstr->str[mmapstr->len - 1] == '\n') {
+  if ((mmapstr->len >= 1) && (mmapstr->str[mmapstr->len - 1] == '\n')) {
     mmapstr->len --;
     mmapstr->str[mmapstr->len] = '\0';
   }
-  if (mmapstr->str[mmapstr->len - 1] == '\r') {
+  if ((mmapstr->len >= 1) && (mmapstr->str[mmapstr->len - 1] == '\r')) {
     mmapstr->len --;
     mmapstr->str[mmapstr->len] = '\0';
   }


### PR DESCRIPTION
It is possible for the string passed to remove_trailing_eol to have a zero length. This causes it to try and read from mmapstr->str[-1] which can cause an illegal memory access. It would also fail if you had 1 character string containing \n.