### PR TITLE
Fix small memory leak in mailimap_hack_date_time_parse()

### DIFF
--- a/src/low-level/imap/mailimap_parser.c
+++ b/src/low-level/imap/mailimap_parser.c
@@ -4515,11 +4515,13 @@ int mailimap_hack_date_time_parse(char * str,
   r = mailimap_date_time_no_quote_parse(fd, buffer, NULL, &cur_token, &date_time,
                                         progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
+    mmap_string_free(buffer);
     return r;
   }
   
   * result = date_time;
   
+  mmap_string_free(buffer);
   return MAILIMAP_NO_ERROR;
 }
 


### PR DESCRIPTION
(free memory allocated by mmap_string_new() before returning.)