### PR TITLE
low-level imf: fix incomplete revert of broken merge

### DIFF
--- a/src/low-level/imf/mailimf.c
+++ b/src/low-level/imf/mailimf.c
@@ -1419,9 +1419,7 @@ int mailimf_quoted_string_parse(const char * message, size_t length,
 	goto free_gstr;
       }
     }
-    else if (r == MAILIMF_ERROR_PARSE) {
-        break;
-    } else {
+    else if (r != MAILIMF_ERROR_PARSE) {
       res = r;
       goto free_gstr;
     }
@@ -1518,9 +1516,7 @@ int mailimf_fws_quoted_string_parse(const char * message, size_t length,
 	goto free_gstr;
       }
     }
-    else if (r == MAILIMF_ERROR_PARSE) {
-        break;
-    } else {
+    else if (r != MAILIMF_ERROR_PARSE) {
       res = r;
       goto free_gstr;
     }


### PR DESCRIPTION
this fixes a2a063830b3352ed6fa839cbd0775e8c0af680b6, an incomplete
revert of commits 829f19ae427b248fec92c357e91b12cabde0f5dd and
fc3c6a6418f0ebf2ca70887398086bbf3a0bdee8 and restores the original
working state of imf field parsing 

this fixes #406 