### PR TITLE
imf field parsing: fix parsing of Resent-Bcc header

### DIFF
--- a/src/low-level/imf/mailimf.c
+++ b/src/low-level/imf/mailimf.c
@@ -6507,7 +6507,7 @@ mailimf_resent_bcc_parse(const char * message, size_t length,
   * result = bcc;
   * indx = cur_token;
 
-  return TRUE;
+  return MAILIMF_NO_ERROR;
 
  free_addr_list:
   mailimf_address_list_free(addr_list);


### PR DESCRIPTION
fix return value of mailimf_resent_bcc_parse in success case
to MAILIMF_NO_ERROR -- currently, TRUE (=1) is returned, which wrongly
causes an error when trying to parse a Resent-Bcc header field