### PR TITLE
revert wrong fix and apply what actually is explained in the comment

### DIFF
--- a/src/driver/tools/mailthread.c
+++ b/src/driver/tools/mailthread.c
@@ -1096,7 +1096,7 @@ mail_build_thread_references(char * default_from,
 	  if (env_tree->node_msg == NULL)
 	    replace = TRUE;
 	  else {
-	    if (!env_tree->node_is_reply)
+	    if (msg_in_table->node_is_reply && !env_tree->node_is_reply)
 	      replace = TRUE;
 	  }
 	}


### PR DESCRIPTION
this reverts commit bd85e6ca3da30157f55b7bed2db741cab0ab6b1f from #352
and changes the admittedly non-sensical if condition to what is described
in the comment a few lines above and what I suppose must have been
the actual intention