### PR TITLE
configure.ac: Improve C99 compatibility of pthread_create check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -482,7 +482,7 @@ elif test "x$enable_threads" = "xyes"; then
   checkpthread=yes
 
   AC_MSG_CHECKING([for pthread_create with libc])
-  AC_TRY_LINK([], [pthread_create();], 
+  AC_TRY_LINK([char pthread_create(void);], [pthread_create();],
                   [pthflag=yes; checkpthread=no], 
                   [pthflag=no])
   AC_MSG_RESULT($pthflag)


### PR DESCRIPTION
Use a fake prototype (similar to the one used by autoconf internally) to avoid calling the undeclared pthread_create function. Otherwie the the check will never succeed with compilers which do not support implicit function declarations.  (Implicit function declarations were removed from C99 in 1999.)

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
