### PR TITLE
Fix mailsmtp_init_with_ip for IPv6 on Linux

### DIFF
--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -277,12 +277,17 @@ static int get_hostname(mailsmtp * session, int useip, char * buf, int len)
       return MAILSMTP_ERROR_HOSTNAME;
 
 #if (defined __linux__ || defined WIN32 || defined __sun)
-    r = getnameinfo(&addr, sizeof(addr), hostname, HOSTNAME_SIZE, NULL, 0, NI_NUMERICHOST);
+    r = getnameinfo(&addr, addr_len, hostname, HOSTNAME_SIZE, NULL, 0, NI_NUMERICHOST);
 #else
     r = getnameinfo(&addr, addr.sa_len, hostname, HOSTNAME_SIZE, NULL, 0, NI_NUMERICHOST);
 #endif
     if (r != 0)
       return MAILSMTP_ERROR_HOSTNAME;
+
+    char* interface_suffix = strstr(hostname, "%");
+    if (interface_suffix != NULL) {
+      *interface_suffix = '\0';
+    }
 
     if (snprintf(buf, len, "[%s]", hostname) >= len)
       return MAILSMTP_ERROR_HOSTNAME;


### PR DESCRIPTION
Hi! 
Firstly, thanks for the great work on this library! I've been using it in my TUI email client [nmail](https://github.com/d99kris/nmail) for 4 years and it's been very solid to work with.

Now to my problem: It appears that `mailsmtp_init_with_ip(smtp, 1)` (i.e. using ip address instead of hostname) fails on Linux when socket address is of IPv6 type.

There are two reasons for this:

1. `getnameinfo()` is called with `sizeof(addr)` (which is 16) so this call fails with `EAI_FAMILY` (-6) for IPv6 addresses. We can fix this by using  `addr_len` which is populated with the actual address length by `getsockname()`.

2. The host address populated by `getnameinfo()` may be suffixed by `%` and a network interface specifier, and at least Gmail does not accept this format, and returns an error like:
```
501-5.5.4 HELO/EHLO argument "[2400:e800:2000:b00:4000:0:600:0%808590000]"
501-5.5.4 invalid, closing connection.
501 5.5.4 https://support.google.com/mail/?p=helo a14-20020a62bd0e000000b0064d413caea6sm3299641pff.179 - gsmtp
```
This can be fixed by simply dropping the interface specifier from the IPv6 address.

I've tested the patch on IPv6 and IPv4 on Linux.