### PR TITLE
Support obs-FWS in the FWS parser (#431)

### DIFF
--- a/src/low-level/imf/mailimf.c
+++ b/src/low-level/imf/mailimf.c
@@ -830,6 +830,7 @@ int mailimf_fws_parse(const char * message, size_t length, size_t * indx)
   int fws_1;
   int fws_2;
   int fws_3;
+  int fws_4;
   int r;
   
   cur_token = * indx;
@@ -847,20 +848,24 @@ int mailimf_fws_parse(const char * message, size_t length, size_t * indx)
   }
   final_token = cur_token;
 
-  r = mailimf_crlf_parse(message, length, &cur_token);
-  switch (r) {
-  case MAILIMF_NO_ERROR:
-    fws_2 = TRUE;
-    break;
-  case MAILIMF_ERROR_PARSE:
-    fws_2 = FALSE;
-    break;
-  default:
-      return r;
-  }
-  
   fws_3 = FALSE;
-  if (fws_2) {
+  fws_4 = FALSE;
+  while (1) {
+    r = mailimf_crlf_parse(message, length, &cur_token);
+    switch (r) {
+    case MAILIMF_NO_ERROR:
+      fws_2 = TRUE;
+      break;
+    case MAILIMF_ERROR_PARSE:
+      fws_2 = FALSE;
+      break;
+    default:
+	return r;
+    }
+    if (!fws_2)
+      break;
+    
+    fws_4 = FALSE;
     while (1) {
       r = mailimf_wsp_parse(message, length, &cur_token);
       if (r != MAILIMF_NO_ERROR) {
@@ -869,14 +874,19 @@ int mailimf_fws_parse(const char * message, size_t length, size_t * indx)
 	else
 	  return r;
       }
+      final_token = cur_token;
       fws_3 = TRUE;
+      fws_4 = TRUE;
     }
+
+    if (!fws_4)
+      break;
   }
 
   if ((!fws_1) && (!fws_3))
     return MAILIMF_ERROR_PARSE;
 
-  if (!fws_3)
+  if (!fws_4)
     cur_token = final_token;
 
   * indx = cur_token;


### PR DESCRIPTION
The function mailimf_fws_parse() does not support obs-FWS, which is defined in RFC5322, section 3.2.2.

For the example in #431, when <msg-id-aaa@example.com> is parsed and mailimf_fws_parse() is called after that, it will set cur_token at the position of '\r' in the 5th line. This will cause problems in certain situations. The example in #431 triggers the problem because the message-id afterwards is invalid. Another examples which also trigger problems are that there is a "WSP CRLF" line in the To header field or there are more than three continuous "WSP CRLF" lines in the References header field (see below).

```
From: AAA <aaa@example.com>
To: BBB <bbb@example.com>,
	
 CCC <ccc@example.com>
References: <msg-id-aaa@example.com>
	
	
	
 <msg-id-bbb@example.com>
Message-ID: <msg-id-ccc@example.com>

A test mail
```


The bugfix here adds the support of obs-FWS and fixes all these problems.
