### PR TITLE
Avoid double-free of the memory allocated inside charconv method

### DIFF
--- a/src/data-types/charconv.c
+++ b/src/data-types/charconv.c
@@ -173,6 +173,7 @@ int charconv(const char * tocode, const char * fromcode,
 			res = (*extended_charconv)( tocode, fromcode, str, length, *result, &result_length);
 			if (res != MAIL_CHARCONV_NO_ERROR) {
 				free( *result);
+				*result = NULL;
 			} else {
 				out = realloc( *result, result_length + 1);
 				if (out != NULL) *result = out;


### PR DESCRIPTION
On iOS 17 beta 1 iconv fails to convert strings for some reason causing a failure which, in turn, causes the memory allocated for a result parameter inside `charconv` method  to be freed two times (first inside `charconv` line 175, and second in the `mailmime_encoded_phrase_parse` line 180).