### PR TITLE
IMAP STATUS: Support RFC 8438 STATUS=SIZE.

### DIFF
--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -339,6 +339,9 @@ static void mailbox_data_store(mailimap * session,
             case MAILIMAP_STATUS_ATT_UNSEEN:
               session->imap_selection_info->unseen = info->value;
               break;
+            case MAILIMAP_STATUS_ATT_SIZE:
+              session->imap_selection_info->size = info->value;
+              break;
           }
         }
       }

--- a/src/low-level/imap/mailimap_keywords.c
+++ b/src/low-level/imap/mailimap_keywords.c
@@ -183,6 +183,7 @@ static struct mailimap_token_value status_att_tab[] = {
   {MAILIMAP_STATUS_ATT_UIDVALIDITY,   "UIDVALIDITY"},
   {MAILIMAP_STATUS_ATT_UNSEEN,        "UNSEEN"},
   {MAILIMAP_STATUS_ATT_HIGHESTMODSEQ, "HIGHESTMODSEQ"},
+  {MAILIMAP_STATUS_ATT_SIZE,          "SIZE"},
 };
 
 int mailimap_status_att_get_token_value(mailstream * fd, MMAPString * buffer,

--- a/src/low-level/imap/mailimap_print.c
+++ b/src/low-level/imap/mailimap_print.c
@@ -942,6 +942,9 @@ static void mailimap_status_att_print(int status_att)
   case MAILIMAP_STATUS_ATT_UNSEEN:
     printf("status att unseen");
     break;
+  case MAILIMAP_STATUS_ATT_SIZE:
+    printf("status att size");
+    break;
   }
 
   printf(" \n");

--- a/src/low-level/imap/mailimap_types.h
+++ b/src/low-level/imap/mailimap_types.h
@@ -455,7 +455,7 @@
    status          = "STATUS" SP mailbox SP "(" status-att *(SP status-att) ")"
 
    status-att      = "MESSAGES" / "RECENT" / "UIDNEXT" / "UIDVALIDITY" /
-                     "UNSEEN"
+                     "UNSEEN" / "SIZE"
 
    store           = "STORE" SP set SP store-att-flags
 
@@ -1572,6 +1572,7 @@ enum {
   MAILIMAP_STATUS_ATT_HIGHESTMODSEQ, /* when requesting the highest
                                         mod-sequence value of all messages in
                                         the mailbox */
+  MAILIMAP_STATUS_ATT_SIZE,          /* when requesting the mailbox size */
   MAILIMAP_STATUS_ATT_EXTENSION
 };
 
@@ -1582,7 +1583,8 @@ enum {
   - att is the type of mailbox STATUS, the value can be 
     MAILIMAP_STATUS_ATT_MESSAGES, MAILIMAP_STATUS_ATT_RECENT,
     MAILIMAP_STATUS_ATT_UIDNEXT, MAILIMAP_STATUS_ATT_UIDVALIDITY,
-    MAILIMAP_STATUS_ATT_UNSEEN or MAILIMAP_STATUS_ATT_EXTENSION
+    MAILIMAP_STATUS_ATT_UNSEEN, MAILIMAP_STATUS_ATT_EXTENSION
+    or MAILIMAP_STATUS_ATT_SIZE
 
   - value is the value of the given information
   
@@ -3154,7 +3156,8 @@ void mailimap_search_key_free(struct mailimap_search_key * key);
   - list is a list of mailbox STATUS request type
     (value of elements in the list can be MAILIMAP_STATUS_ATT_MESSAGES,
     MAILIMAP_STATUS_ATT_RECENT, MAILIMAP_STATUS_ATT_UIDNEXT,
-    MAILIMAP_STATUS_ATT_UIDVALIDITY or MAILIMAP_STATUS_ATT_UNSEEN),
+    MAILIMAP_STATUS_ATT_UIDVALIDITY, MAILIMAP_STATUS_ATT_UNSEEN
+    or MAILIMAP_STATUS_ATT_SIZE),
     each element should be allocated with malloc()
 */
 


### PR DESCRIPTION
Add support for RFC 8438 STATUS=SIZE, which allows adding "SIZE" to the STATUS command to get the mailbox size.
This avoids having to do FETCH 1:* (SIZE) to get the mailbox size, increasing efficiency.