### PR TITLE
mailsmtp: Allow authentication without SASL.

### DIFF
--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -959,8 +959,8 @@ int auth_map_errors(int err)
   }
 }
 
-#if 0
-static int mailsmtp_auth_login(mailsmtp * session,
+LIBETPAN_EXPORT
+int mailsmtp_auth_login(mailsmtp * session,
     const char * user, const char * pass)
 {
   int err;
@@ -1008,7 +1008,6 @@ static int mailsmtp_auth_login(mailsmtp * session,
   
   return err;
 }
-#endif
 
 int mailsmtp_auth_type(mailsmtp * session,
     const char * user, const char * pass, int type)
@@ -1634,16 +1633,19 @@ void mailsmtp_set_logger(mailsmtp * session, void (* logger)(mailsmtp * session,
   session->smtp_logger_context = logger_context;
 }
 
+LIBETPAN_EXPORT
 int mailsmtp_send_command(mailsmtp * f, char * command)
 {
   return send_command(f, command);
 }
 
+LIBETPAN_EXPORT
 int mailsmtp_send_command_private(mailsmtp * f, char * command)
 {
     return send_command_private(f, command, 0);
 }
 
+LIBETPAN_EXPORT
 int mailsmtp_read_response(mailsmtp * session)
 {
   return read_response(session);

--- a/src/low-level/smtp/mailsmtp.h
+++ b/src/low-level/smtp/mailsmtp.h
@@ -67,6 +67,7 @@ int mailsmtp_connect(mailsmtp * session, mailstream * s);
 LIBETPAN_EXPORT
 int mailsmtp_quit(mailsmtp * session);
 
+int mailsmtp_auth_login(mailsmtp * session, const char * user, const char * pass);
 
 /* This call is deprecated and mailesmtp_auth_sasl() should be used instead */
 /**
@@ -184,6 +185,15 @@ LIBETPAN_EXPORT
 void mailsmtp_set_logger(mailsmtp * session, void (* logger)(mailsmtp * session, int log_type,
     const char * str, size_t size, void * context), void * logger_context);
    
+LIBETPAN_EXPORT
+int mailsmtp_send_command(mailsmtp * f, char * command);
+
+LIBETPAN_EXPORT
+int mailsmtp_send_command_private(mailsmtp * f, char * command);
+
+LIBETPAN_EXPORT
+int mailsmtp_read_response(mailsmtp * session);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
libetpan currently does not allow authentication at all, without USE_SASL, which is an unnecessary limitation and a serious impediment to the usability of the SMTP portion of the library. This fix is twofold:

* Uncomment and export mailsmtp_auth_login, for AUTH LOGIN.
* Export commands for sending custom commands and reading responses (which is already possible with the IMAP library, so consistent with that). This is necessary for sending custom AUTH commands parts of other AUTH commands.