### PR TITLE
FIX: operator precedence related to poll

### DIFF
--- a/src/data-types/connect.c
+++ b/src/data-types/connect.c
@@ -159,7 +159,7 @@ static int wait_connect(int s, int r, time_t timeout_seconds)
     return -1;
   }
   
-  if (pfd.revents & POLLOUT != POLLOUT) {
+  if ((pfd.revents & POLLOUT) != POLLOUT) {
     return -1;
   }
 #endif

--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -365,7 +365,7 @@ static int wait_SSL_connect(int s, int want_read, time_t timeout_seconds)
     return -1;
   }
 
-  if (pfd.revents & pfd.events != pfd.events) {
+  if ((pfd.revents & pfd.events) != pfd.events) {
     return -1;
   }
 #endif


### PR DESCRIPTION
Fixes the following warnings:

```
connect.c:162:19: warning: suggest parentheses around comparison in operand of ‘&’ [-Wparentheses]
mailstream_ssl.c:368:32: warning: self-comparison always evaluates to false [-Wtautological-compare]
mailstream_ssl.c:368:32: warning: suggest parentheses around comparison in operand of ‘&’ [-Wparentheses]
```