### PR TITLE
Add Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,73 @@
+// swift-tools-version:5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "libetpan",
+    platforms: [
+        .iOS(.v12), .macOS(.v10_13)
+    ],
+    products: [
+        .library(
+            name: "libetpan",
+            targets: ["libetpan"]),
+    ],
+    targets: [
+        .target(name: "libetpan",
+                path: ".",
+                exclude: ["src/windows",
+                          "src/bsd"],
+                sources: ["src"],
+                publicHeadersPath: "spm_include",
+                cSettings: [
+                    .headerSearchPath("spm_include/libetpan"),
+                    .headerSearchPath("src/data-types"),
+                    .headerSearchPath("src/low-level/feed"),
+                    .headerSearchPath("src/low-level/imap"),
+                    .headerSearchPath("src/low-level/imf"),
+                    .headerSearchPath("src/low-level/maildir"),
+                    .headerSearchPath("src/low-level/mbox"),
+                    .headerSearchPath("src/low-level/mh"),
+                    .headerSearchPath("src/low-level/mime"),
+                    .headerSearchPath("src/low-level/nntp"),
+                    .headerSearchPath("src/low-level/pop3"),
+                    .headerSearchPath("src/low-level/smtp"),
+                    .headerSearchPath("src/driver/implementation"),
+                    .headerSearchPath("src/driver/interface"),
+                    .headerSearchPath("src/driver/tools"),
+                    .define("HAVE_LIMITS_H"),
+                    .define("HAVE_UNISTD_H"),
+                    .define("HAVE_SYS_MMAN_H"),
+                    .define("HAVE_INTTYPES_H"),
+                    .define("HAVE_CFNETWORK"),
+                    .define("HAVE_SYS_PARAM_H"),
+                    .define("HAVE_MEMORY_H"),
+                    .define("HAVE_MMAP"),
+                    .define("HAVE_NETINET_IN_H"),
+                    .define("HAVE_PTHREAD_H"),
+                    .define("HAVE_STDINT_H"),
+                    .define("HAVE_STDLIB_H"),
+                    .define("HAVE_STRINGS_H"),
+                    .define("HAVE_SYS_PARAM_H"),
+                    .define("HAVE_SYS_SELECT_H"),
+                    .define("HAVE_SYS_STAT_H"),
+                    .define("HAVE_SYS_TYPES_H"),
+                    .define("HAVE_UNISTD_H"),
+                    .define("HAVE_SYS_SOCKET_H"),
+                    .define("HAVE_ZLIB"),
+                    .define("LIBETPAN_REENTRANT"),
+                    .define("PACKAGE", to: "libetpan"),
+                    .define("USE_SASL", .when(platforms: [.macOS]))
+                ],
+                linkerSettings: [
+                    .linkedLibrary("iconv"),
+                    .linkedLibrary("z"),
+                    .linkedLibrary("sasl2", .when(platforms: [.macOS])),
+                    .linkedLibrary("c")
+                ]),
+        
+    ],
+    cLanguageStandard: .gnu11,
+    cxxLanguageStandard: .cxx20
+)

--- a/spm_include/libetpan/acl.h
+++ b/spm_include/libetpan/acl.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/acl.h

--- a/spm_include/libetpan/acl_parser.h
+++ b/spm_include/libetpan/acl_parser.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/acl_parser.h

--- a/spm_include/libetpan/acl_sender.h
+++ b/spm_include/libetpan/acl_sender.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/acl_sender.h

--- a/spm_include/libetpan/acl_types.h
+++ b/spm_include/libetpan/acl_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/acl_types.h

--- a/spm_include/libetpan/annotatemore.h
+++ b/spm_include/libetpan/annotatemore.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/annotatemore.h

--- a/spm_include/libetpan/annotatemore_parser.h
+++ b/spm_include/libetpan/annotatemore_parser.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/annotatemore_parser.h

--- a/spm_include/libetpan/annotatemore_sender.h
+++ b/spm_include/libetpan/annotatemore_sender.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/annotatemore_sender.h

--- a/spm_include/libetpan/annotatemore_types.h
+++ b/spm_include/libetpan/annotatemore_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/annotatemore_types.h

--- a/spm_include/libetpan/base64.h
+++ b/spm_include/libetpan/base64.h
@@ -1,0 +1,1 @@
+../../src/data-types/base64.h

--- a/spm_include/libetpan/carray.h
+++ b/spm_include/libetpan/carray.h
@@ -1,0 +1,1 @@
+../../src/data-types/carray.h

--- a/spm_include/libetpan/charconv.h
+++ b/spm_include/libetpan/charconv.h
@@ -1,0 +1,1 @@
+../../src/data-types/charconv.h

--- a/spm_include/libetpan/chash.h
+++ b/spm_include/libetpan/chash.h
@@ -1,0 +1,1 @@
+../../src/data-types/chash.h

--- a/spm_include/libetpan/clientid.h
+++ b/spm_include/libetpan/clientid.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/clientid.h

--- a/spm_include/libetpan/clientid_sender.h
+++ b/spm_include/libetpan/clientid_sender.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/clientid_sender.h

--- a/spm_include/libetpan/clist.h
+++ b/spm_include/libetpan/clist.h
@@ -1,0 +1,1 @@
+../../src/data-types/clist.h

--- a/spm_include/libetpan/condstore.h
+++ b/spm_include/libetpan/condstore.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/condstore.h

--- a/spm_include/libetpan/condstore_private.h
+++ b/spm_include/libetpan/condstore_private.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/condstore_private.h

--- a/spm_include/libetpan/condstore_types.h
+++ b/spm_include/libetpan/condstore_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/condstore_types.h

--- a/spm_include/libetpan/connect.h
+++ b/spm_include/libetpan/connect.h
@@ -1,0 +1,1 @@
+../../src/data-types/connect.h

--- a/spm_include/libetpan/data_message_driver.h
+++ b/spm_include/libetpan/data_message_driver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/data-message/data_message_driver.h

--- a/spm_include/libetpan/date.h
+++ b/spm_include/libetpan/date.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/date.h

--- a/spm_include/libetpan/dbdriver.h
+++ b/spm_include/libetpan/dbdriver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/db/dbdriver.h

--- a/spm_include/libetpan/dbdriver_message.h
+++ b/spm_include/libetpan/dbdriver_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/db/dbdriver_message.h

--- a/spm_include/libetpan/dbdriver_types.h
+++ b/spm_include/libetpan/dbdriver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/db/dbdriver_types.h

--- a/spm_include/libetpan/dbstorage.h
+++ b/spm_include/libetpan/dbstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/db/dbstorage.h

--- a/spm_include/libetpan/enable.h
+++ b/spm_include/libetpan/enable.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/enable.h

--- a/spm_include/libetpan/feeddriver.h
+++ b/spm_include/libetpan/feeddriver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/feed/feeddriver.h

--- a/spm_include/libetpan/feeddriver_message.h
+++ b/spm_include/libetpan/feeddriver_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/feed/feeddriver_message.h

--- a/spm_include/libetpan/feeddriver_types.h
+++ b/spm_include/libetpan/feeddriver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/feed/feeddriver_types.h

--- a/spm_include/libetpan/feedstorage.h
+++ b/spm_include/libetpan/feedstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/feed/feedstorage.h

--- a/spm_include/libetpan/generic_cache.h
+++ b/spm_include/libetpan/generic_cache.h
@@ -1,0 +1,1 @@
+../../src/driver/tools/generic_cache.h

--- a/spm_include/libetpan/generic_cache_types.h
+++ b/spm_include/libetpan/generic_cache_types.h
@@ -1,0 +1,1 @@
+../../src/driver/tools/generic_cache_types.h

--- a/spm_include/libetpan/getopt.h
+++ b/spm_include/libetpan/getopt.h
@@ -1,0 +1,1 @@
+../../src/bsd/getopt.h

--- a/spm_include/libetpan/hmac-md5.h
+++ b/spm_include/libetpan/hmac-md5.h
@@ -1,0 +1,1 @@
+../../src/data-types/hmac-md5.h

--- a/spm_include/libetpan/hotmailstorage.h
+++ b/spm_include/libetpan/hotmailstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/hotmail/hotmailstorage.h

--- a/spm_include/libetpan/idle.h
+++ b/spm_include/libetpan/idle.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/idle.h

--- a/spm_include/libetpan/imapdriver.h
+++ b/spm_include/libetpan/imapdriver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/imap/imapdriver.h

--- a/spm_include/libetpan/imapdriver_cached.h
+++ b/spm_include/libetpan/imapdriver_cached.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/imap/imapdriver_cached.h

--- a/spm_include/libetpan/imapdriver_cached_message.h
+++ b/spm_include/libetpan/imapdriver_cached_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/imap/imapdriver_cached_message.h

--- a/spm_include/libetpan/imapdriver_message.h
+++ b/spm_include/libetpan/imapdriver_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/imap/imapdriver_message.h

--- a/spm_include/libetpan/imapdriver_tools.h
+++ b/spm_include/libetpan/imapdriver_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/imap/imapdriver_tools.h

--- a/spm_include/libetpan/imapdriver_tools_private.h
+++ b/spm_include/libetpan/imapdriver_tools_private.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/imap/imapdriver_tools_private.h

--- a/spm_include/libetpan/imapdriver_types.h
+++ b/spm_include/libetpan/imapdriver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/imap/imapdriver_types.h

--- a/spm_include/libetpan/imapstorage.h
+++ b/spm_include/libetpan/imapstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/imap/imapstorage.h

--- a/spm_include/libetpan/imfcache.h
+++ b/spm_include/libetpan/imfcache.h
@@ -1,0 +1,1 @@
+../../src/driver/tools/imfcache.h

--- a/spm_include/libetpan/libetpan-config.h
+++ b/spm_include/libetpan/libetpan-config.h
@@ -1,0 +1,202 @@
+#ifndef LIBETPAN_CONFIG_H
+#define LIBETPAN_CONFIG_H
+
+#ifndef CONFIG_H
+#define CONFIG_H
+#endif
+
+/* Define to detected Berkeley DB major version number */
+/* #undef DBVERS */
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#define HAVE_ARPA_INET_H 1
+
+/* Define to 1 if you have the <ctype.h> header file. */
+#define HAVE_CTYPE_H 1
+
+/* Define to use curl */
+/* #undef HAVE_CURL */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to use expat */
+/* #undef HAVE_EXPAT */
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to use getopt_long */
+#define HAVE_GETOPT_LONG 1
+
+/* Define to 1 if you have the `getpagesize' function. */
+#define HAVE_GETPAGESIZE 1
+
+/* Define if you have the iconv() function. */
+/* #undef HAVE_ICONV */
+
+/* prototype of iconv() has const parameters */
+/* #undef HAVE_ICONV_PROTO_CONST */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to enable IPv6 support. */
+#define HAVE_IPV6 1
+
+/* Define to 1 if you have the `lockfile' library (-llockfile). */
+/* #undef HAVE_LIBLOCKFILE */
+
+/* Define to 1 if you have the `nsl' library (-lnsl). */
+/* #undef HAVE_LIBNSL */
+
+/* Define to 1 if you have the `socket' library (-lsocket). */
+/* #undef HAVE_LIBSOCKET */
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have a working `mmap' system call. */
+#define HAVE_MMAP 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+/* #undef HAVE_NETDB_H */
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#define HAVE_NETINET_IN_H 1
+
+/* Define to 1 if you have the <pthread.h> header file. */
+#define HAVE_PTHREAD_H 1
+
+/* Define to use setenv */
+#define HAVE_SETENV 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#define HAVE_SYS_MMAN_H 1
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#define HAVE_SYS_SELECT_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#define HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the CFNetwork library. */
+#define HAVE_CFNETWORK 1
+
+/* Enable classes using zlib compression. */
+#define HAVE_ZLIB 1
+
+/* Define to include multithreading support */
+#define LIBETPAN_REENTRANT 1
+
+/* Define this to the version of libEtPan */
+#define LIBETPAN_VERSION "1.2-dev-20141203"
+
+/* Define this to the major version of libEtPan */
+#define LIBETPAN_VERSION_MAJOR 1
+
+/* Define this to the minor version of libEtPan */
+#define LIBETPAN_VERSION_MINOR 2
+
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "libetpan"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "libetpan-devel@lists.sourceforge.net"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libetpan"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libetpan 1.2"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libetpan"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.2"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to be lazy on protocol syntax */
+#define UNSTRICT_SYNTAX 1
+
+/* Define to use GnuTLS */
+/* #undef USE_GNUTLS */
+
+/* Define to use SASL */
+#import <TargetConditionals.h>
+
+#if TARGET_OS_MAC && !TARGET_OS_IOS
+#define USE_SASL 1
+#endif
+
+/* Version number of package */
+#define VERSION "1.2"
+
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#ifdef HAVE_SYS_PARAM_H
+/* support for ARM platforms with a 2.95.3 arm-gcc suite */
+#include <sys/param.h>
+#endif
+
+#ifdef HAVE_INTTYPES_H
+#include <inttypes.h>
+#endif
+
+#define MAIL_DIR_SEPARATOR '/'
+#define MAIL_DIR_SEPARATOR_S "/"
+
+#ifdef _MSC_VER
+#   ifdef LIBETPAN_DLL
+#       define LIBETPAN_EXPORT __declspec(dllexport)
+#   else
+#       define LIBETPAN_EXPORT __declspec(dllimport)
+#   endif
+#else
+#   define LIBETPAN_EXPORT
+#endif
+
+#endif /* LIBETPAN_CONFIG_H */

--- a/spm_include/libetpan/libetpan.h
+++ b/spm_include/libetpan/libetpan.h
@@ -1,0 +1,1 @@
+../../src/main/libetpan.h

--- a/spm_include/libetpan/libetpan_version.h
+++ b/spm_include/libetpan/libetpan_version.h
@@ -1,0 +1,20 @@
+#ifndef LIBETPAN_VERSION_H
+
+#define LIBETPAN_VERSION_H
+
+#ifndef LIBETPAN_VERSION_MAJOR
+#define LIBETPAN_VERSION_MAJOR 1
+#endif
+
+#ifndef LIBETPAN_VERSION_MINOR
+#define LIBETPAN_VERSION_MINOR 6
+#endif
+
+#ifndef LIBETPAN_REENTRANT
+#define LIBETPAN_REENTRANT 1
+#endif
+
+int libetpan_get_version_major(void);
+int libetpan_get_version_minor(void);
+
+#endif

--- a/spm_include/libetpan/mail.h
+++ b/spm_include/libetpan/mail.h
@@ -1,0 +1,1 @@
+../../src/data-types/mail.h

--- a/spm_include/libetpan/mail_cache_db.h
+++ b/spm_include/libetpan/mail_cache_db.h
@@ -1,0 +1,1 @@
+../../src/data-types/mail_cache_db.h

--- a/spm_include/libetpan/mail_cache_db_types.h
+++ b/spm_include/libetpan/mail_cache_db_types.h
@@ -1,0 +1,1 @@
+../../src/data-types/mail_cache_db_types.h

--- a/spm_include/libetpan/maildir.h
+++ b/spm_include/libetpan/maildir.h
@@ -1,0 +1,1 @@
+../../src/low-level/maildir/maildir.h

--- a/spm_include/libetpan/maildir_types.h
+++ b/spm_include/libetpan/maildir_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/maildir/maildir_types.h

--- a/spm_include/libetpan/maildirdriver.h
+++ b/spm_include/libetpan/maildirdriver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/maildir/maildirdriver.h

--- a/spm_include/libetpan/maildirdriver_cached.h
+++ b/spm_include/libetpan/maildirdriver_cached.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/maildir/maildirdriver_cached.h

--- a/spm_include/libetpan/maildirdriver_cached_message.h
+++ b/spm_include/libetpan/maildirdriver_cached_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/maildir/maildirdriver_cached_message.h

--- a/spm_include/libetpan/maildirdriver_message.h
+++ b/spm_include/libetpan/maildirdriver_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/maildir/maildirdriver_message.h

--- a/spm_include/libetpan/maildirdriver_tools.h
+++ b/spm_include/libetpan/maildirdriver_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/maildir/maildirdriver_tools.h

--- a/spm_include/libetpan/maildirdriver_types.h
+++ b/spm_include/libetpan/maildirdriver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/maildir/maildirdriver_types.h

--- a/spm_include/libetpan/maildirstorage.h
+++ b/spm_include/libetpan/maildirstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/maildir/maildirstorage.h

--- a/spm_include/libetpan/maildriver.h
+++ b/spm_include/libetpan/maildriver.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/maildriver.h

--- a/spm_include/libetpan/maildriver_errors.h
+++ b/spm_include/libetpan/maildriver_errors.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/maildriver_errors.h

--- a/spm_include/libetpan/maildriver_tools.h
+++ b/spm_include/libetpan/maildriver_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/maildriver_tools.h

--- a/spm_include/libetpan/maildriver_types.h
+++ b/spm_include/libetpan/maildriver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/maildriver_types.h

--- a/spm_include/libetpan/maildriver_types_helper.h
+++ b/spm_include/libetpan/maildriver_types_helper.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/maildriver_types_helper.h

--- a/spm_include/libetpan/mailengine.h
+++ b/spm_include/libetpan/mailengine.h
@@ -1,0 +1,1 @@
+../../src/engine/mailengine.h

--- a/spm_include/libetpan/mailfolder.h
+++ b/spm_include/libetpan/mailfolder.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/mailfolder.h

--- a/spm_include/libetpan/mailimap.h
+++ b/spm_include/libetpan/mailimap.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap.h

--- a/spm_include/libetpan/mailimap_compress.h
+++ b/spm_include/libetpan/mailimap_compress.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_compress.h

--- a/spm_include/libetpan/mailimap_extension.h
+++ b/spm_include/libetpan/mailimap_extension.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_extension.h

--- a/spm_include/libetpan/mailimap_extension_types.h
+++ b/spm_include/libetpan/mailimap_extension_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_extension_types.h

--- a/spm_include/libetpan/mailimap_helper.h
+++ b/spm_include/libetpan/mailimap_helper.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_helper.h

--- a/spm_include/libetpan/mailimap_id.h
+++ b/spm_include/libetpan/mailimap_id.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_id.h

--- a/spm_include/libetpan/mailimap_id_parser.h
+++ b/spm_include/libetpan/mailimap_id_parser.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_id_parser.h

--- a/spm_include/libetpan/mailimap_id_sender.h
+++ b/spm_include/libetpan/mailimap_id_sender.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_id_sender.h

--- a/spm_include/libetpan/mailimap_id_types.h
+++ b/spm_include/libetpan/mailimap_id_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_id_types.h

--- a/spm_include/libetpan/mailimap_keywords.h
+++ b/spm_include/libetpan/mailimap_keywords.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_keywords.h

--- a/spm_include/libetpan/mailimap_oauth2.h
+++ b/spm_include/libetpan/mailimap_oauth2.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_oauth2.h

--- a/spm_include/libetpan/mailimap_parser.h
+++ b/spm_include/libetpan/mailimap_parser.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_parser.h

--- a/spm_include/libetpan/mailimap_print.h
+++ b/spm_include/libetpan/mailimap_print.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_print.h

--- a/spm_include/libetpan/mailimap_sender.h
+++ b/spm_include/libetpan/mailimap_sender.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_sender.h

--- a/spm_include/libetpan/mailimap_socket.h
+++ b/spm_include/libetpan/mailimap_socket.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_socket.h

--- a/spm_include/libetpan/mailimap_sort.h
+++ b/spm_include/libetpan/mailimap_sort.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_sort.h

--- a/spm_include/libetpan/mailimap_sort_types.h
+++ b/spm_include/libetpan/mailimap_sort_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_sort_types.h

--- a/spm_include/libetpan/mailimap_ssl.h
+++ b/spm_include/libetpan/mailimap_ssl.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_ssl.h

--- a/spm_include/libetpan/mailimap_types.h
+++ b/spm_include/libetpan/mailimap_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_types.h

--- a/spm_include/libetpan/mailimap_types_helper.h
+++ b/spm_include/libetpan/mailimap_types_helper.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/mailimap_types_helper.h

--- a/spm_include/libetpan/mailimf.h
+++ b/spm_include/libetpan/mailimf.h
@@ -1,0 +1,1 @@
+../../src/low-level/imf/mailimf.h

--- a/spm_include/libetpan/mailimf_types.h
+++ b/spm_include/libetpan/mailimf_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imf/mailimf_types.h

--- a/spm_include/libetpan/mailimf_types_helper.h
+++ b/spm_include/libetpan/mailimf_types_helper.h
@@ -1,0 +1,1 @@
+../../src/low-level/imf/mailimf_types_helper.h

--- a/spm_include/libetpan/mailimf_write.h
+++ b/spm_include/libetpan/mailimf_write.h
@@ -1,0 +1,1 @@
+../../src/low-level/imf/mailimf_write.h

--- a/spm_include/libetpan/mailimf_write_file.h
+++ b/spm_include/libetpan/mailimf_write_file.h
@@ -1,0 +1,1 @@
+../../src/low-level/imf/mailimf_write_file.h

--- a/spm_include/libetpan/mailimf_write_generic.h
+++ b/spm_include/libetpan/mailimf_write_generic.h
@@ -1,0 +1,1 @@
+../../src/low-level/imf/mailimf_write_generic.h

--- a/spm_include/libetpan/mailimf_write_mem.h
+++ b/spm_include/libetpan/mailimf_write_mem.h
@@ -1,0 +1,1 @@
+../../src/low-level/imf/mailimf_write_mem.h

--- a/spm_include/libetpan/maillock.h
+++ b/spm_include/libetpan/maillock.h
@@ -1,0 +1,1 @@
+../../src/data-types/maillock.h

--- a/spm_include/libetpan/mailmbox.h
+++ b/spm_include/libetpan/mailmbox.h
@@ -1,0 +1,1 @@
+../../src/low-level/mbox/mailmbox.h

--- a/spm_include/libetpan/mailmbox_parse.h
+++ b/spm_include/libetpan/mailmbox_parse.h
@@ -1,0 +1,1 @@
+../../src/low-level/mbox/mailmbox_parse.h

--- a/spm_include/libetpan/mailmbox_types.h
+++ b/spm_include/libetpan/mailmbox_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/mbox/mailmbox_types.h

--- a/spm_include/libetpan/mailmessage.h
+++ b/spm_include/libetpan/mailmessage.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/mailmessage.h

--- a/spm_include/libetpan/mailmessage_tools.h
+++ b/spm_include/libetpan/mailmessage_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/mailmessage_tools.h

--- a/spm_include/libetpan/mailmessage_types.h
+++ b/spm_include/libetpan/mailmessage_types.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/mailmessage_types.h

--- a/spm_include/libetpan/mailmh.h
+++ b/spm_include/libetpan/mailmh.h
@@ -1,0 +1,1 @@
+../../src/low-level/mh/mailmh.h

--- a/spm_include/libetpan/mailmime.h
+++ b/spm_include/libetpan/mailmime.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime.h

--- a/spm_include/libetpan/mailmime_content.h
+++ b/spm_include/libetpan/mailmime_content.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_content.h

--- a/spm_include/libetpan/mailmime_decode.h
+++ b/spm_include/libetpan/mailmime_decode.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_decode.h

--- a/spm_include/libetpan/mailmime_disposition.h
+++ b/spm_include/libetpan/mailmime_disposition.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_disposition.h

--- a/spm_include/libetpan/mailmime_types.h
+++ b/spm_include/libetpan/mailmime_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_types.h

--- a/spm_include/libetpan/mailmime_types_helper.h
+++ b/spm_include/libetpan/mailmime_types_helper.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_types_helper.h

--- a/spm_include/libetpan/mailmime_write.h
+++ b/spm_include/libetpan/mailmime_write.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_write.h

--- a/spm_include/libetpan/mailmime_write_file.h
+++ b/spm_include/libetpan/mailmime_write_file.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_write_file.h

--- a/spm_include/libetpan/mailmime_write_generic.h
+++ b/spm_include/libetpan/mailmime_write_generic.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_write_generic.h

--- a/spm_include/libetpan/mailmime_write_mem.h
+++ b/spm_include/libetpan/mailmime_write_mem.h
@@ -1,0 +1,1 @@
+../../src/low-level/mime/mailmime_write_mem.h

--- a/spm_include/libetpan/mailpop3.h
+++ b/spm_include/libetpan/mailpop3.h
@@ -1,0 +1,1 @@
+../../src/low-level/pop3/mailpop3.h

--- a/spm_include/libetpan/mailpop3_helper.h
+++ b/spm_include/libetpan/mailpop3_helper.h
@@ -1,0 +1,1 @@
+../../src/low-level/pop3/mailpop3_helper.h

--- a/spm_include/libetpan/mailpop3_socket.h
+++ b/spm_include/libetpan/mailpop3_socket.h
@@ -1,0 +1,1 @@
+../../src/low-level/pop3/mailpop3_socket.h

--- a/spm_include/libetpan/mailpop3_ssl.h
+++ b/spm_include/libetpan/mailpop3_ssl.h
@@ -1,0 +1,1 @@
+../../src/low-level/pop3/mailpop3_ssl.h

--- a/spm_include/libetpan/mailpop3_types.h
+++ b/spm_include/libetpan/mailpop3_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/pop3/mailpop3_types.h

--- a/spm_include/libetpan/mailprivacy.h
+++ b/spm_include/libetpan/mailprivacy.h
@@ -1,0 +1,1 @@
+../../src/engine/mailprivacy.h

--- a/spm_include/libetpan/mailprivacy_gnupg.h
+++ b/spm_include/libetpan/mailprivacy_gnupg.h
@@ -1,0 +1,1 @@
+../../src/engine/mailprivacy_gnupg.h

--- a/spm_include/libetpan/mailprivacy_smime.h
+++ b/spm_include/libetpan/mailprivacy_smime.h
@@ -1,0 +1,1 @@
+../../src/engine/mailprivacy_smime.h

--- a/spm_include/libetpan/mailprivacy_tools.h
+++ b/spm_include/libetpan/mailprivacy_tools.h
@@ -1,0 +1,1 @@
+../../src/engine/mailprivacy_tools.h

--- a/spm_include/libetpan/mailprivacy_tools_private.h
+++ b/spm_include/libetpan/mailprivacy_tools_private.h
@@ -1,0 +1,1 @@
+../../src/engine/mailprivacy_tools_private.h

--- a/spm_include/libetpan/mailprivacy_types.h
+++ b/spm_include/libetpan/mailprivacy_types.h
@@ -1,0 +1,1 @@
+../../src/engine/mailprivacy_types.h

--- a/spm_include/libetpan/mailsasl.h
+++ b/spm_include/libetpan/mailsasl.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailsasl.h

--- a/spm_include/libetpan/mailsasl_private.h
+++ b/spm_include/libetpan/mailsasl_private.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailsasl_private.h

--- a/spm_include/libetpan/mailsem.h
+++ b/spm_include/libetpan/mailsem.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailsem.h

--- a/spm_include/libetpan/mailsmtp.h
+++ b/spm_include/libetpan/mailsmtp.h
@@ -1,0 +1,1 @@
+../../src/low-level/smtp/mailsmtp.h

--- a/spm_include/libetpan/mailsmtp_helper.h
+++ b/spm_include/libetpan/mailsmtp_helper.h
@@ -1,0 +1,1 @@
+../../src/low-level/smtp/mailsmtp_helper.h

--- a/spm_include/libetpan/mailsmtp_oauth2.h
+++ b/spm_include/libetpan/mailsmtp_oauth2.h
@@ -1,0 +1,1 @@
+../../src/low-level/smtp/mailsmtp_oauth2.h

--- a/spm_include/libetpan/mailsmtp_private.h
+++ b/spm_include/libetpan/mailsmtp_private.h
@@ -1,0 +1,1 @@
+../../src/low-level/smtp/mailsmtp_private.h

--- a/spm_include/libetpan/mailsmtp_socket.h
+++ b/spm_include/libetpan/mailsmtp_socket.h
@@ -1,0 +1,1 @@
+../../src/low-level/smtp/mailsmtp_socket.h

--- a/spm_include/libetpan/mailsmtp_ssl.h
+++ b/spm_include/libetpan/mailsmtp_ssl.h
@@ -1,0 +1,1 @@
+../../src/low-level/smtp/mailsmtp_ssl.h

--- a/spm_include/libetpan/mailsmtp_types.h
+++ b/spm_include/libetpan/mailsmtp_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/smtp/mailsmtp_types.h

--- a/spm_include/libetpan/mailstorage.h
+++ b/spm_include/libetpan/mailstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/mailstorage.h

--- a/spm_include/libetpan/mailstorage_tools.h
+++ b/spm_include/libetpan/mailstorage_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/mailstorage_tools.h

--- a/spm_include/libetpan/mailstorage_types.h
+++ b/spm_include/libetpan/mailstorage_types.h
@@ -1,0 +1,1 @@
+../../src/driver/interface/mailstorage_types.h

--- a/spm_include/libetpan/mailstream.h
+++ b/spm_include/libetpan/mailstream.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream.h

--- a/spm_include/libetpan/mailstream_cancel.h
+++ b/spm_include/libetpan/mailstream_cancel.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_cancel.h

--- a/spm_include/libetpan/mailstream_cancel_types.h
+++ b/spm_include/libetpan/mailstream_cancel_types.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_cancel_types.h

--- a/spm_include/libetpan/mailstream_cfstream.h
+++ b/spm_include/libetpan/mailstream_cfstream.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_cfstream.h

--- a/spm_include/libetpan/mailstream_compress.h
+++ b/spm_include/libetpan/mailstream_compress.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_compress.h

--- a/spm_include/libetpan/mailstream_helper.h
+++ b/spm_include/libetpan/mailstream_helper.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_helper.h

--- a/spm_include/libetpan/mailstream_low.h
+++ b/spm_include/libetpan/mailstream_low.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_low.h

--- a/spm_include/libetpan/mailstream_socket.h
+++ b/spm_include/libetpan/mailstream_socket.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_socket.h

--- a/spm_include/libetpan/mailstream_ssl.h
+++ b/spm_include/libetpan/mailstream_ssl.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_ssl.h

--- a/spm_include/libetpan/mailstream_ssl_private.h
+++ b/spm_include/libetpan/mailstream_ssl_private.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_ssl_private.h

--- a/spm_include/libetpan/mailstream_types.h
+++ b/spm_include/libetpan/mailstream_types.h
@@ -1,0 +1,1 @@
+../../src/data-types/mailstream_types.h

--- a/spm_include/libetpan/mailthread.h
+++ b/spm_include/libetpan/mailthread.h
@@ -1,0 +1,1 @@
+../../src/driver/tools/mailthread.h

--- a/spm_include/libetpan/mailthread_types.h
+++ b/spm_include/libetpan/mailthread_types.h
@@ -1,0 +1,1 @@
+../../src/driver/tools/mailthread_types.h

--- a/spm_include/libetpan/mboxdriver.h
+++ b/spm_include/libetpan/mboxdriver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mbox/mboxdriver.h

--- a/spm_include/libetpan/mboxdriver_cached.h
+++ b/spm_include/libetpan/mboxdriver_cached.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mbox/mboxdriver_cached.h

--- a/spm_include/libetpan/mboxdriver_cached_message.h
+++ b/spm_include/libetpan/mboxdriver_cached_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mbox/mboxdriver_cached_message.h

--- a/spm_include/libetpan/mboxdriver_message.h
+++ b/spm_include/libetpan/mboxdriver_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mbox/mboxdriver_message.h

--- a/spm_include/libetpan/mboxdriver_tools.h
+++ b/spm_include/libetpan/mboxdriver_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mbox/mboxdriver_tools.h

--- a/spm_include/libetpan/mboxdriver_types.h
+++ b/spm_include/libetpan/mboxdriver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mbox/mboxdriver_types.h

--- a/spm_include/libetpan/mboxstorage.h
+++ b/spm_include/libetpan/mboxstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mbox/mboxstorage.h

--- a/spm_include/libetpan/md5.h
+++ b/spm_include/libetpan/md5.h
@@ -1,0 +1,1 @@
+../../src/data-types/md5.h

--- a/spm_include/libetpan/md5global.h
+++ b/spm_include/libetpan/md5global.h
@@ -1,0 +1,1 @@
+../../src/data-types/md5global.h

--- a/spm_include/libetpan/md5namespace.h
+++ b/spm_include/libetpan/md5namespace.h
@@ -1,0 +1,1 @@
+../../src/data-types/md5namespace.h

--- a/spm_include/libetpan/mhdriver.h
+++ b/spm_include/libetpan/mhdriver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mh/mhdriver.h

--- a/spm_include/libetpan/mhdriver_cached.h
+++ b/spm_include/libetpan/mhdriver_cached.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mh/mhdriver_cached.h

--- a/spm_include/libetpan/mhdriver_cached_message.h
+++ b/spm_include/libetpan/mhdriver_cached_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mh/mhdriver_cached_message.h

--- a/spm_include/libetpan/mhdriver_message.h
+++ b/spm_include/libetpan/mhdriver_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mh/mhdriver_message.h

--- a/spm_include/libetpan/mhdriver_tools.h
+++ b/spm_include/libetpan/mhdriver_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mh/mhdriver_tools.h

--- a/spm_include/libetpan/mhdriver_types.h
+++ b/spm_include/libetpan/mhdriver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mh/mhdriver_types.h

--- a/spm_include/libetpan/mhstorage.h
+++ b/spm_include/libetpan/mhstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mh/mhstorage.h

--- a/spm_include/libetpan/mime_message_driver.h
+++ b/spm_include/libetpan/mime_message_driver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/mime-message/mime_message_driver.h

--- a/spm_include/libetpan/mmapstring.h
+++ b/spm_include/libetpan/mmapstring.h
@@ -1,0 +1,1 @@
+../../src/data-types/mmapstring.h

--- a/spm_include/libetpan/mmapstring_private.h
+++ b/spm_include/libetpan/mmapstring_private.h
@@ -1,0 +1,1 @@
+../../src/data-types/mmapstring_private.h

--- a/spm_include/libetpan/namespace.h
+++ b/spm_include/libetpan/namespace.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/namespace.h

--- a/spm_include/libetpan/namespace_parser.h
+++ b/spm_include/libetpan/namespace_parser.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/namespace_parser.h

--- a/spm_include/libetpan/namespace_sender.h
+++ b/spm_include/libetpan/namespace_sender.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/namespace_sender.h

--- a/spm_include/libetpan/namespace_types.h
+++ b/spm_include/libetpan/namespace_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/namespace_types.h

--- a/spm_include/libetpan/newsfeed.h
+++ b/spm_include/libetpan/newsfeed.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/newsfeed.h

--- a/spm_include/libetpan/newsfeed_item.h
+++ b/spm_include/libetpan/newsfeed_item.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/newsfeed_item.h

--- a/spm_include/libetpan/newsfeed_item_enclosure.h
+++ b/spm_include/libetpan/newsfeed_item_enclosure.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/newsfeed_item_enclosure.h

--- a/spm_include/libetpan/newsfeed_private.h
+++ b/spm_include/libetpan/newsfeed_private.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/newsfeed_private.h

--- a/spm_include/libetpan/newsfeed_types.h
+++ b/spm_include/libetpan/newsfeed_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/newsfeed_types.h

--- a/spm_include/libetpan/newsnntp.h
+++ b/spm_include/libetpan/newsnntp.h
@@ -1,0 +1,1 @@
+../../src/low-level/nntp/newsnntp.h

--- a/spm_include/libetpan/newsnntp_socket.h
+++ b/spm_include/libetpan/newsnntp_socket.h
@@ -1,0 +1,1 @@
+../../src/low-level/nntp/newsnntp_socket.h

--- a/spm_include/libetpan/newsnntp_ssl.h
+++ b/spm_include/libetpan/newsnntp_ssl.h
@@ -1,0 +1,1 @@
+../../src/low-level/nntp/newsnntp_ssl.h

--- a/spm_include/libetpan/newsnntp_types.h
+++ b/spm_include/libetpan/newsnntp_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/nntp/newsnntp_types.h

--- a/spm_include/libetpan/nntpdriver.h
+++ b/spm_include/libetpan/nntpdriver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/nntp/nntpdriver.h

--- a/spm_include/libetpan/nntpdriver_cached.h
+++ b/spm_include/libetpan/nntpdriver_cached.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/nntp/nntpdriver_cached.h

--- a/spm_include/libetpan/nntpdriver_cached_message.h
+++ b/spm_include/libetpan/nntpdriver_cached_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/nntp/nntpdriver_cached_message.h

--- a/spm_include/libetpan/nntpdriver_message.h
+++ b/spm_include/libetpan/nntpdriver_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/nntp/nntpdriver_message.h

--- a/spm_include/libetpan/nntpdriver_tools.h
+++ b/spm_include/libetpan/nntpdriver_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/nntp/nntpdriver_tools.h

--- a/spm_include/libetpan/nntpdriver_types.h
+++ b/spm_include/libetpan/nntpdriver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/nntp/nntpdriver_types.h

--- a/spm_include/libetpan/nntpstorage.h
+++ b/spm_include/libetpan/nntpstorage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/nntp/nntpstorage.h

--- a/spm_include/libetpan/parser.h
+++ b/spm_include/libetpan/parser.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/parser.h

--- a/spm_include/libetpan/parser_atom03.h
+++ b/spm_include/libetpan/parser_atom03.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/parser_atom03.h

--- a/spm_include/libetpan/parser_atom10.h
+++ b/spm_include/libetpan/parser_atom10.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/parser_atom10.h

--- a/spm_include/libetpan/parser_rdf.h
+++ b/spm_include/libetpan/parser_rdf.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/parser_rdf.h

--- a/spm_include/libetpan/parser_rss20.h
+++ b/spm_include/libetpan/parser_rss20.h
@@ -1,0 +1,1 @@
+../../src/low-level/feed/parser_rss20.h

--- a/spm_include/libetpan/pop3driver.h
+++ b/spm_include/libetpan/pop3driver.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/pop3/pop3driver.h

--- a/spm_include/libetpan/pop3driver_cached.h
+++ b/spm_include/libetpan/pop3driver_cached.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/pop3/pop3driver_cached.h

--- a/spm_include/libetpan/pop3driver_cached_message.h
+++ b/spm_include/libetpan/pop3driver_cached_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/pop3/pop3driver_cached_message.h

--- a/spm_include/libetpan/pop3driver_message.h
+++ b/spm_include/libetpan/pop3driver_message.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/pop3/pop3driver_message.h

--- a/spm_include/libetpan/pop3driver_tools.h
+++ b/spm_include/libetpan/pop3driver_tools.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/pop3/pop3driver_tools.h

--- a/spm_include/libetpan/pop3driver_types.h
+++ b/spm_include/libetpan/pop3driver_types.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/pop3/pop3driver_types.h

--- a/spm_include/libetpan/pop3storage.h
+++ b/spm_include/libetpan/pop3storage.h
@@ -1,0 +1,1 @@
+../../src/driver/implementation/pop3/pop3storage.h

--- a/spm_include/libetpan/qresync.h
+++ b/spm_include/libetpan/qresync.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/qresync.h

--- a/spm_include/libetpan/qresync_private.h
+++ b/spm_include/libetpan/qresync_private.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/qresync_private.h

--- a/spm_include/libetpan/qresync_types.h
+++ b/spm_include/libetpan/qresync_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/qresync_types.h

--- a/spm_include/libetpan/quota.h
+++ b/spm_include/libetpan/quota.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/quota.h

--- a/spm_include/libetpan/quota_parser.h
+++ b/spm_include/libetpan/quota_parser.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/quota_parser.h

--- a/spm_include/libetpan/quota_sender.h
+++ b/spm_include/libetpan/quota_sender.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/quota_sender.h

--- a/spm_include/libetpan/quota_types.h
+++ b/spm_include/libetpan/quota_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/quota_types.h

--- a/spm_include/libetpan/timeutils.h
+++ b/spm_include/libetpan/timeutils.h
@@ -1,0 +1,1 @@
+../../src/data-types/timeutils.h

--- a/spm_include/libetpan/uidplus.h
+++ b/spm_include/libetpan/uidplus.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/uidplus.h

--- a/spm_include/libetpan/uidplus_parser.h
+++ b/spm_include/libetpan/uidplus_parser.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/uidplus_parser.h

--- a/spm_include/libetpan/uidplus_sender.h
+++ b/spm_include/libetpan/uidplus_sender.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/uidplus_sender.h

--- a/spm_include/libetpan/uidplus_types.h
+++ b/spm_include/libetpan/uidplus_types.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/uidplus_types.h

--- a/spm_include/libetpan/win_etpan.h
+++ b/spm_include/libetpan/win_etpan.h
@@ -1,0 +1,1 @@
+../../src/windows/win_etpan.h

--- a/spm_include/libetpan/xgmlabels.h
+++ b/spm_include/libetpan/xgmlabels.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/xgmlabels.h

--- a/spm_include/libetpan/xgmmsgid.h
+++ b/spm_include/libetpan/xgmmsgid.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/xgmmsgid.h

--- a/spm_include/libetpan/xgmthrid.h
+++ b/spm_include/libetpan/xgmthrid.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/xgmthrid.h

--- a/spm_include/libetpan/xlist.h
+++ b/spm_include/libetpan/xlist.h
@@ -1,0 +1,1 @@
+../../src/low-level/imap/xlist.h


### PR DESCRIPTION
Adds a Package.swift file so that this library can be used via SPM.

Notably, this will be used upstream by [MailCore](https://github.com/MailCore/mailcore2/). It includes symlinks to the relevant header files to allow SPM to create the correct module.