### PR TITLE
configure.ac: remove outdated libtool macros 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,8 +145,8 @@ AC_C_INLINE
 
 # Checks for programs.
 LT_INIT(win32-dll)
-LT_AC_PROG_RC
-AC_LIBTOOL_RC
+LT_PROG_RC
+LT_LANG(Windows Resource)
 AC_PROG_LIBTOOL
 AC_PROG_MKDIR_P
 


### PR DESCRIPTION
* `LT_AC_PROG_RC` is an old name for `LT_PROG_RC`.
* `AC_LIBTOOL_RC` is an old name for `LT_LANG(Windows Resource)`.

From the libtool ChangeLog:
```
2004-03-21  Scott James Remnant  <scott@netsplit.com>
         (LT_AC_PROG_RC): Renamed to LT_PROG_RC.
    
2009-06-27  Charles Wilson  <libtool@cwilson.fastmail.fm>
         Add alias for obsoleted AC_LIBTOOL_RC macro.
```