### PR TITLE
imap: fix MMAPString allocator-mismatch leaks on consumer side (regression from #455)

### DIFF
--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -225,10 +225,13 @@ static void resp_text_store(mailimap * session,
       
     case MAILIMAP_RESP_TEXT_CODE_OTHER:
       if (session->imap_response_info) {
+        /* Previous values were transferred from the parser's atom/custom-string
+           allocators (MMAPString-registered). Use the matching free helpers
+           so the hashtable entry is released; plain free() leaks them. */
         if (session->imap_response_info->rsp_atom != NULL)
-          free(session->imap_response_info->rsp_atom);
+          mailimap_atom_free(session->imap_response_info->rsp_atom);
         if (session->imap_response_info->rsp_value != NULL)
-          free(session->imap_response_info->rsp_value);
+          mailimap_text_free(session->imap_response_info->rsp_value);
 	session->imap_response_info->rsp_atom =
           resp_text_code->rc_data.rc_atom.atom_name;
         resp_text_code->rc_data.rc_atom.atom_name = NULL;

--- a/src/low-level/imap/mailimap_parser.c
+++ b/src/low-level/imap/mailimap_parser.c
@@ -10226,8 +10226,11 @@ mailimap_resp_text_code_other_parse(mailstream * fd, MMAPString * buffer, struct
   return MAILIMAP_NO_ERROR;
 
  free_value:
+  /* value was produced by mailimap_custom_string_parse (MMAPString-registered);
+     mailimap_text_free routes through mmap_string_unref so the hashtable entry
+     is released. Plain free() would leak the MMAPString header + entry. */
   if (value != NULL)
-    free(value);
+    mailimap_text_free(value);
   mailimap_atom_free(atom);
  err:
   return res;

--- a/src/low-level/imap/mailimap_types.c
+++ b/src/low-level/imap/mailimap_types.c
@@ -152,14 +152,16 @@ void mailimap_astring_free(char * astring)
 
 static void mailimap_custom_string_free(char * str)
 {
-  free(str);
+  if (mmap_string_unref(str) != 0)
+    free(str);
 }
 
 
 LIBETPAN_EXPORT
 void mailimap_atom_free(char * atom)
 {
-  free(atom);
+  if (mmap_string_unref(atom) != 0)
+    free(atom);
 }
 
 
@@ -779,10 +781,10 @@ void mailimap_capability_free(struct mailimap_capability * c)
 {
   switch (c->cap_type) {
   case MAILIMAP_CAPABILITY_AUTH_TYPE:
-    free(c->cap_data.cap_auth_type);
+    mailimap_auth_type_free(c->cap_data.cap_auth_type);
     break;
   case MAILIMAP_CAPABILITY_NAME:
-    free(c->cap_data.cap_name);
+    mailimap_atom_free(c->cap_data.cap_name);
     break;
   }
   free(c);

--- a/src/low-level/imap/mailimap_types.c
+++ b/src/low-level/imap/mailimap_types.c
@@ -3199,8 +3199,11 @@ LIBETPAN_EXPORT
 void
 mailimap_response_info_free(struct mailimap_response_info * resp_info)
 {
-  free(resp_info->rsp_value);
-  free(resp_info->rsp_atom);
+  /* rsp_value and rsp_atom hold MMAPString-registered buffers (custom-string
+     and atom allocator respectively). Plain free() here would skip the
+     hashtable unref and leak the MMAPString header + the entry. */
+  mailimap_text_free(resp_info->rsp_value);
+  mailimap_atom_free(resp_info->rsp_atom);
   if (resp_info->rsp_alert != NULL)
     free(resp_info->rsp_alert);
   if (resp_info->rsp_parse != NULL)


### PR DESCRIPTION
Fixes the leak @InterLinked1 reported in #455.

After #455 registered atom/custom-string parser output with the
mmapstring hashtable, several consumer-side sites still called plain
free() on those pointers — mmap_string_unref then misses, leaking the
buffer's MMAPString header + chash entry per call. The hottest path is
mailimap_response_info_free at session teardown, which fires on every
mailimap_connect against a server whose greeting includes a
RESP_TEXT_CODE_OTHER (e.g. `OK [CAPABILITY …]`).

abd2822 — capability_free + atom_free/custom_string_free fallback
c72b0df — response_info_free, resp_text_store OTHER re-store,
          resp_text_code_other_parse OOM path

All consumer sites now route through the matching free helper, which
mmap_string_unref + fall back to free() for legacy pointers.

Verified:
  * fuzz_imap_response stress: ~770 B/iter leak on master, RSS flat on
    this branch over 10k iterations.
  * Targeted driver under valgrind: 24,000 allocs / 24,000 frees,
    all heap freed, 0 errors.
