### PR TITLE
Do not require cxx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -815,4 +815,4 @@ AC_SUBST(cfg_files)
 AC_OUTPUT
 
 cp -f ${crd}/src/main/libetpan_version.h ${crd}/build-windows
-cd build-windows ; ./gen-public-headers.sh > build_headers.list ; cd ..
+( cd "${srcdir}/build-windows" ; ./gen-public-headers.sh > build_headers.list )

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,6 +49,16 @@ libetpan_deps = $(libetpan_res)
 
 else
 
+# For the sake of Windows build a dummy.cpp file is present to force
+# automake to generate link command in C++ mode. However it does so
+# unconditionally so that requires a C++ compiler unnecessarily.
+#
+# This hack forces C linking when not building for Windows.
+libetpan@LIBSUFFIX@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+        $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CC) \
+        $(AM_CFLAGS) $(CFLAGS) $(libetpan_la_LDFLAGS) \
+        $(LDFLAGS) -o $@
+
 libetpan_res =
 libetpan_res_ldflag =
 no_undefined =


### PR DESCRIPTION
Since libetpan is a C library it shouldn't normally require g++ or other C++ compiler to be fully buildable and usable on a standard system. Windows being an exception can remain an exception. One can reproduce the issue by temprorarily moving g++ and clang++ out of the way so that configure and libtool can not see them, then the shared library libetpan.so is not generated at all.