### PR TITLE
fix(version): restore LIBETPAN_VERSION_MICRO and libetpan_get_version_micro()

### DIFF
--- a/build-spm/include/libetpan/libetpan_version.h
+++ b/build-spm/include/libetpan/libetpan_version.h
@@ -41,13 +41,31 @@
 #define LIBETPAN_VERSION_MINOR 10
 #endif
 
+#ifndef LIBETPAN_VERSION_MICRO
+#define LIBETPAN_VERSION_MICRO 1
+#endif
+
 #ifndef LIBETPAN_REENTRANT
 #if 1
 #define LIBETPAN_REENTRANT 1
 #endif
+
+#ifndef LIBETPAN_API_CURRENT
+#define LIBETPAN_API_CURRENT 26
+#endif
+
+#ifndef LIBETPAN_API_REVISION
+#define LIBETPAN_API_REVISION 0
+#endif
+
+#ifndef LIBETPAN_API_COMPATIBILITY
+#define LIBETPAN_API_COMPATIBILITY 26
+#endif
+
 #endif
 
 int libetpan_get_version_major(void);
 int libetpan_get_version_minor(void);
+int libetpan_get_version_micro(void);
 
 #endif

--- a/build-windows/libetpan_version.h
+++ b/build-windows/libetpan_version.h
@@ -38,16 +38,34 @@
 #endif
 
 #ifndef LIBETPAN_VERSION_MINOR
-#define LIBETPAN_VERSION_MINOR 6
+#define LIBETPAN_VERSION_MINOR 10
+#endif
+
+#ifndef LIBETPAN_VERSION_MICRO
+#define LIBETPAN_VERSION_MICRO 1
 #endif
 
 #ifndef LIBETPAN_REENTRANT
 #if 1
 #define LIBETPAN_REENTRANT 1
 #endif
+
+#ifndef LIBETPAN_API_CURRENT
+#define LIBETPAN_API_CURRENT 26
+#endif
+
+#ifndef LIBETPAN_API_REVISION
+#define LIBETPAN_API_REVISION 0
+#endif
+
+#ifndef LIBETPAN_API_COMPATIBILITY
+#define LIBETPAN_API_COMPATIBILITY 26
+#endif
+
 #endif
 
 int libetpan_get_version_major(void);
 int libetpan_get_version_minor(void);
+int libetpan_get_version_micro(void);
 
 #endif

--- a/src/main/libetpan_version.c
+++ b/src/main/libetpan_version.c
@@ -50,3 +50,8 @@ int libetpan_get_version_minor(void)
 {
   return LIBETPAN_VERSION_MINOR;
 }
+
+int libetpan_get_version_micro(void)
+{
+  return LIBETPAN_VERSION_MICRO;
+}

--- a/src/main/libetpan_version.h.in
+++ b/src/main/libetpan_version.h.in
@@ -41,13 +41,31 @@
 #define LIBETPAN_VERSION_MINOR @VERSION_MINOR@
 #endif
 
+#ifndef LIBETPAN_VERSION_MICRO
+#define LIBETPAN_VERSION_MICRO @VERSION_MICRO@
+#endif
+
 #ifndef LIBETPAN_REENTRANT
 #if @REENTRANT@
 #define LIBETPAN_REENTRANT 1
 #endif
+
+#ifndef LIBETPAN_API_CURRENT
+#define LIBETPAN_API_CURRENT @API_CURRENT@
+#endif
+
+#ifndef LIBETPAN_API_REVISION
+#define LIBETPAN_API_REVISION @API_REVISION@
+#endif
+
+#ifndef LIBETPAN_API_COMPATIBILITY
+#define LIBETPAN_API_COMPATIBILITY @API_COMPATIBILITY@
+#endif
+
 #endif
 
 int libetpan_get_version_major(void);
 int libetpan_get_version_minor(void);
+int libetpan_get_version_micro(void);
 
 #endif


### PR DESCRIPTION
### Fix:
  - Restore LIBETPAN_VERSION_MICRO, the LIBETPAN_API_* macros, and the libetpan_get_version_micro() declaration/definition in src/main/libetpan_version.h.in and libetpan_version.c.
  - Restore the same in the prebuilt build-spm and build-windows headers, and fix build-windows LIBETPAN_VERSION_MINOR back to 10.
  - Regenerate build-mac/autogen-result.tar.gz from the current configure.ac (1.10.1) so the Android/iOS builds get a configure and config.h.in that define VERSION_MICRO.

  Verified: generated config.h reports 1.10.1 with
  LIBETPAN_VERSION_MICRO,
  and libetpan_version.c compiles against both the
  autotools and SPM
  configs; Android build succeeds.